### PR TITLE
Updated Grimsby name

### DIFF
--- a/data/120/924/212/9/1209242129.geojson
+++ b/data/120/924/212/9/1209242129.geojson
@@ -29,6 +29,12 @@
     "lbl:longitude":-0.09888,
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
+    "name:eng_x_preferred":[
+        "Grimsby"
+    ],
+    "name:eng_x_variant":[
+        "Grimbsy"
+    ],
     "nav:latitude":53.55989,
     "nav:longitude":-0.09888,
     "src:geom":"whosonfirst",
@@ -61,8 +67,8 @@
         }
     ],
     "wof:id":1209242129,
-    "wof:lastmodified":1547766618,
-    "wof:name":"Grimbsy",
+    "wof:lastmodified":1557941341,
+    "wof:name":"Grimsby",
     "wof:parent_id":1360817097,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-gb",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1608.

Updates name properties, as well as `wof:name`.
No PIP required, can merge once approved.