### PR TITLE
Updated Headley name

### DIFF
--- a/data/112/596/492/3/1125964923.geojson
+++ b/data/112/596/492/3/1125964923.geojson
@@ -18,6 +18,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Headley"
+    ],
+    "name:eng_x_variant":[
+        "Hardley"
+    ],
     "qs_pg:aaroncc":"GB",
     "qs_pg:gn_country":"GB",
     "qs_pg:gn_fcode":"PPL",
@@ -79,8 +85,8 @@
         }
     ],
     "wof:id":1125964923,
-    "wof:lastmodified":1547723516,
-    "wof:name":"Hardley",
+    "wof:lastmodified":1559345018,
+    "wof:name":"Headley",
     "wof:parent_id":404439513,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-gb",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1630.

This PR updates the locality name to "Headley" instead of (the incorrect) "Hardley". No PIP work required, property edit only.