### PR TITLE
Fix UK shortcode, remove deprecated lang prop

### DIFF
--- a/data/856/331/59/85633159.geojson
+++ b/data/856/331/59/85633159.geojson
@@ -1220,9 +1220,6 @@
         }
     ],
     "wof:id":85633159,
-    "wof:lang":[
-        "eng"
-    ],
     "wof:lang_x_official":[
         "eng"
     ],
@@ -1232,14 +1229,14 @@
         "gla",
         "gle"
     ],
-    "wof:lastmodified":1544059183,
+    "wof:lastmodified":1559775713,
     "wof:name":"United Kingdom",
     "wof:parent_id":102191581,
     "wof:placetype":"country",
     "wof:population":63705000,
     "wof:population_rank":16,
     "wof:repo":"whosonfirst-data-admin-gb",
-    "wof:shortcode":"GB",
+    "wof:shortcode":"UK",
     "wof:superseded_by":[],
     "wof:supersedes":[],
     "wof:tags":[]


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1618

- Changes the `wof:shortcode` value to `UK`
- Removes deprecated `wof:lang` property
- Exportifies record

Does not require PIP work to update hierarchy. Can merge once approved.