### PR TITLE
Update sovereign base areas

### DIFF
--- a/data/856/323/87/85632387.geojson
+++ b/data/856/323/87/85632387.geojson
@@ -9,7 +9,6 @@
     "geom:bbox":"33.673705,34.942779541,33.916555,35.123731",
     "geom:latitude":35.018441,
     "geom:longitude":33.790093,
-    "gp:id":0,
     "iso:country":"XY",
     "iso:parent":"GB",
     "lbl:latitude":35.020556,
@@ -27,6 +26,9 @@
         "\u0394\u03b5\u03ba\u03ad\u03bb\u03b5\u03b9\u03b1"
     ],
     "name:eng_x_preferred":[
+        "Dhekelia"
+    ],
+    "name:eng_x_variant":[
         "Dhekelia Sovereign Base Area"
     ],
     "name:tur_x_preferred":[
@@ -69,6 +71,7 @@
         "wof:parent_id"
     ],
     "wof:country":"GB",
+    "wof:country_alpha3":"XEB",
     "wof:geomhash":"b2b24146abd8438162cb9ce59bffb882",
     "wof:hierarchy":[
         {
@@ -78,8 +81,9 @@
         }
     ],
     "wof:id":85632387,
-    "wof:lastmodified":1536617531,
-    "wof:name":"Dhekelia Sovereign Base Area",
+    "wof:label":"Dhekelia Sovereign Base Area",
+    "wof:lastmodified":1560189716,
+    "wof:name":"Dhekelia",
     "wof:parent_id":136253055,
     "wof:placetype":"dependency",
     "wof:placetype_alt":[

--- a/data/856/327/43/85632743.geojson
+++ b/data/856/327/43/85632743.geojson
@@ -9,7 +9,6 @@
     "geom:bbox":"32.754901003,34.562026978,33.03780365,34.705774",
     "geom:latitude":34.637683,
     "geom:longitude":32.923225,
-    "gp:id":0,
     "iso:country":"XY",
     "iso:parent":"GB",
     "lbl:latitude":34.60353,
@@ -37,6 +36,9 @@
     ],
     "name:eng_x_preferred":[
         "Akrotiri"
+    ],
+    "name:eng_x_variant":[
+        "Akrotiri Sovereign Base Area"
     ],
     "name:epo_x_preferred":[
         "Akrotiri"
@@ -102,6 +104,7 @@
         "wof:parent_id"
     ],
     "wof:country":"GB",
+    "wof:country_alpha3":"XWB",
     "wof:geomhash":"7518ee60cea1047eb5a08e296c023945",
     "wof:hierarchy":[
         {
@@ -111,7 +114,8 @@
         }
     ],
     "wof:id":85632743,
-    "wof:lastmodified":1536617536,
+    "wof:label":"Akrotiri Sovereign Base Area",
+    "wof:lastmodified":1560189712,
     "wof:name":"Akrotiri",
     "wof:parent_id":136253055,
     "wof:placetype":"dependency",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1314.

- Adds `wof:label` property to Sovereign Base Area dependency records
- Adds `wof:country_alpha3` property to Sovereign Base Area dependency records
- Cleans up various properties

The new `X*` alpha codes are unique. No PIP work needed, can merge once approved.