### PR TITLE
New neighbourhood records

### DIFF
--- a/data/144/482/979/7/1444829797.geojson
+++ b/data/144/482/979/7/1444829797.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444829797,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.14474304326,52.6677041581,-1.14474304326,52.6677041581",
+    "geom:latitude":52.667704,
+    "geom:longitude":-1.144743,
+    "iso:country":"GB",
+    "lbl:latitude":52.667704,
+    "lbl:longitude":-1.144743,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Mowmacre Hill"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"6ec327024de2c7cb08fb1fc2244b76d0",
+    "wof:hierarchy":[],
+    "wof:id":1444829797,
+    "wof:lastmodified":1566334994,
+    "wof:name":"Mowmacre Hill",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.144743043256418,
+    52.66770415807139,
+    -1.144743043256418,
+    52.66770415807139
+],
+  "geometry": {"coordinates":[-1.14474304325642,52.66770415807139],"type":"Point"}
+}

--- a/data/144/482/979/7/1444829797.geojson
+++ b/data/144/482/979/7/1444829797.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"6ec327024de2c7cb08fb1fc2244b76d0",
-    "wof:hierarchy":[],
+    "wof:geomhash":"4d6659b55861a2bc11eda248258aa410",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444829797,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444829797,
-    "wof:lastmodified":1566334994,
+    "wof:lastmodified":1566336881,
     "wof:name":"Mowmacre Hill",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.144743043256418,
+    -1.14474304325642,
     52.66770415807139,
-    -1.144743043256418,
+    -1.14474304325642,
     52.66770415807139
 ],
   "geometry": {"coordinates":[-1.14474304325642,52.66770415807139],"type":"Point"}

--- a/data/144/482/980/9/1444829809.geojson
+++ b/data/144/482/980/9/1444829809.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444829809,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.10560422962,52.6646503983,-1.10560422962,52.6646503983",
+    "geom:latitude":52.66465,
+    "geom:longitude":-1.105604,
+    "iso:country":"GB",
+    "lbl:latitude":52.66465,
+    "lbl:longitude":-1.105604,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Rushey Mead"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"7ca5f2f8fc5c1d20c0de94665b40ba71",
+    "wof:hierarchy":[],
+    "wof:id":1444829809,
+    "wof:lastmodified":1566334995,
+    "wof:name":"Rushey Mead",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.105604229618339,
+    52.66465039830648,
+    -1.105604229618339,
+    52.66465039830648
+],
+  "geometry": {"coordinates":[-1.10560422961834,52.66465039830648],"type":"Point"}
+}

--- a/data/144/482/980/9/1444829809.geojson
+++ b/data/144/482/980/9/1444829809.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"7ca5f2f8fc5c1d20c0de94665b40ba71",
-    "wof:hierarchy":[],
+    "wof:geomhash":"66e6c7c3003a27fc04d1ab3a27512d86",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444829809,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444829809,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336884,
     "wof:name":"Rushey Mead",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.105604229618339,
+    -1.10560422961834,
     52.66465039830648,
-    -1.105604229618339,
+    -1.10560422961834,
     52.66465039830648
 ],
   "geometry": {"coordinates":[-1.10560422961834,52.66465039830648],"type":"Point"}

--- a/data/144/482/981/9/1444829819.geojson
+++ b/data/144/482/981/9/1444829819.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"5c5661a1a9ce0805b175064f9a9121b6",
-    "wof:hierarchy":[],
+    "wof:geomhash":"6c1f5f654427641676b03dfad5457f9e",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444829819,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444829819,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336884,
     "wof:name":"Humberstone Garden City",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.065321006224761,
+    -1.06532100622476,
     52.64875352121234,
-    -1.065321006224761,
+    -1.06532100622476,
     52.64875352121234
 ],
   "geometry": {"coordinates":[-1.06532100622476,52.64875352121234],"type":"Point"}

--- a/data/144/482/981/9/1444829819.geojson
+++ b/data/144/482/981/9/1444829819.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444829819,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.06532100622,52.6487535212,-1.06532100622,52.6487535212",
+    "geom:latitude":52.648754,
+    "geom:longitude":-1.065321,
+    "iso:country":"GB",
+    "lbl:latitude":52.648753,
+    "lbl:longitude":-1.065321,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Humberstone Garden City"
+    ],
+    "name:eng_x_variant":[
+        "Humberstone Garden"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"5c5661a1a9ce0805b175064f9a9121b6",
+    "wof:hierarchy":[],
+    "wof:id":1444829819,
+    "wof:lastmodified":1566334995,
+    "wof:name":"Humberstone Garden City",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.065321006224761,
+    52.64875352121234,
+    -1.065321006224761,
+    52.64875352121234
+],
+  "geometry": {"coordinates":[-1.06532100622476,52.64875352121234],"type":"Point"}
+}

--- a/data/144/482/983/1/1444829831.geojson
+++ b/data/144/482/983/1/1444829831.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"efa95984267922595cd170b168e2d61a",
-    "wof:hierarchy":[],
+    "wof:geomhash":"b02c2ba8080bf0dab5fd0838f7731e80",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444829831,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444829831,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336885,
     "wof:name":"Nether Hall",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.055250200376367,
+    -1.05525020037637,
     52.64917010702344,
-    -1.055250200376367,
+    -1.05525020037637,
     52.64917010702344
 ],
   "geometry": {"coordinates":[-1.05525020037637,52.64917010702344],"type":"Point"}

--- a/data/144/482/983/1/1444829831.geojson
+++ b/data/144/482/983/1/1444829831.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444829831,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.05525020038,52.649170107,-1.05525020038,52.649170107",
+    "geom:latitude":52.64917,
+    "geom:longitude":-1.05525,
+    "iso:country":"GB",
+    "lbl:latitude":52.64917,
+    "lbl:longitude":-1.05525,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Nether Hall"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"efa95984267922595cd170b168e2d61a",
+    "wof:hierarchy":[],
+    "wof:id":1444829831,
+    "wof:lastmodified":1566334995,
+    "wof:name":"Nether Hall",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.055250200376367,
+    52.64917010702344,
+    -1.055250200376367,
+    52.64917010702344
+],
+  "geometry": {"coordinates":[-1.05525020037637,52.64917010702344],"type":"Point"}
+}

--- a/data/144/482/984/3/1444829843.geojson
+++ b/data/144/482/984/3/1444829843.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"6edd280dc9a7cf0affd7f958fe2e44f6",
-    "wof:hierarchy":[],
+    "wof:geomhash":"a015530ba2fbb46b3b54e204c66898dc",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444829843,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444829843,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336886,
     "wof:name":"Northfields",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -43,9 +60,9 @@
 },
   "bbox": [
     -1.10068326766969,
-    52.648406363338125,
+    52.64840636333813,
     -1.10068326766969,
-    52.648406363338125
+    52.64840636333813
 ],
   "geometry": {"coordinates":[-1.10068326766969,52.64840636333813],"type":"Point"}
 }

--- a/data/144/482/984/3/1444829843.geojson
+++ b/data/144/482/984/3/1444829843.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444829843,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.10068326767,52.6484063633,-1.10068326767,52.6484063633",
+    "geom:latitude":52.648406,
+    "geom:longitude":-1.100683,
+    "iso:country":"GB",
+    "lbl:latitude":52.648406,
+    "lbl:longitude":-1.100683,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Northfields"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"6edd280dc9a7cf0affd7f958fe2e44f6",
+    "wof:hierarchy":[],
+    "wof:id":1444829843,
+    "wof:lastmodified":1566334995,
+    "wof:name":"Northfields",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.10068326766969,
+    52.648406363338125,
+    -1.10068326766969,
+    52.648406363338125
+],
+  "geometry": {"coordinates":[-1.10068326766969,52.64840636333813],"type":"Point"}
+}

--- a/data/144/482/985/3/1444829853.geojson
+++ b/data/144/482/985/3/1444829853.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444829853,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.12311369888,52.6416015126,-1.12311369888,52.6416015126",
+    "geom:latitude":52.641602,
+    "geom:longitude":-1.123114,
+    "iso:country":"GB",
+    "lbl:latitude":52.641602,
+    "lbl:longitude":-1.123114,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Saint Matthew's"
+    ],
+    "name:eng_x_variant":[
+        "St. Matthew's"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"8bfebb52454596bdbfd8a9934f190d05",
+    "wof:hierarchy":[],
+    "wof:id":1444829853,
+    "wof:lastmodified":1566334995,
+    "wof:name":"Saint Matthew's",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.123113698877474,
+    52.641601512603195,
+    -1.123113698877474,
+    52.641601512603195
+],
+  "geometry": {"coordinates":[-1.12311369887747,52.6416015126032],"type":"Point"}
+}

--- a/data/144/482/985/3/1444829853.geojson
+++ b/data/144/482/985/3/1444829853.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"8bfebb52454596bdbfd8a9934f190d05",
-    "wof:hierarchy":[],
+    "wof:geomhash":"662637ad0029ac81da09fcd33ac76497",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444829853,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444829853,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336889,
     "wof:name":"Saint Matthew's",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,10 +62,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.123113698877474,
-    52.641601512603195,
-    -1.123113698877474,
-    52.641601512603195
+    -1.12311369887747,
+    52.6416015126032,
+    -1.12311369887747,
+    52.6416015126032
 ],
   "geometry": {"coordinates":[-1.12311369887747,52.6416015126032],"type":"Point"}
 }

--- a/data/144/482/985/7/1444829857.geojson
+++ b/data/144/482/985/7/1444829857.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444829857,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.14188201887,52.6422959336,-1.14188201887,52.6422959336",
+    "geom:latitude":52.642296,
+    "geom:longitude":-1.141882,
+    "iso:country":"GB",
+    "lbl:latitude":52.642296,
+    "lbl:longitude":-1.141882,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Frog Island"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"3d98c4ab3f74e1de7e5e5234e9883258",
+    "wof:hierarchy":[],
+    "wof:id":1444829857,
+    "wof:lastmodified":1566334995,
+    "wof:name":"Frog Island",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.141882018867661,
+    52.64229593363543,
+    -1.141882018867661,
+    52.64229593363543
+],
+  "geometry": {"coordinates":[-1.14188201886766,52.64229593363543],"type":"Point"}
+}

--- a/data/144/482/985/7/1444829857.geojson
+++ b/data/144/482/985/7/1444829857.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"3d98c4ab3f74e1de7e5e5234e9883258",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d08344fa61de7a6a085853e47cfb3a16",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444829857,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444829857,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336889,
     "wof:name":"Frog Island",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.141882018867661,
+    -1.14188201886766,
     52.64229593363543,
-    -1.141882018867661,
+    -1.14188201886766,
     52.64229593363543
 ],
   "geometry": {"coordinates":[-1.14188201886766,52.64229593363543],"type":"Point"}

--- a/data/144/482/986/9/1444829869.geojson
+++ b/data/144/482/986/9/1444829869.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444829869,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.1702633808,52.6463927933,-1.1702633808,52.6463927933",
+    "geom:latitude":52.646393,
+    "geom:longitude":-1.170263,
+    "iso:country":"GB",
+    "lbl:latitude":52.646393,
+    "lbl:longitude":-1.170263,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "New Parks"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"f2ee72e8a22c8f4497ad36f40260dcd4",
+    "wof:hierarchy":[],
+    "wof:id":1444829869,
+    "wof:lastmodified":1566334995,
+    "wof:name":"New Parks",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.170263380804041,
+    52.646392793318334,
+    -1.170263380804041,
+    52.646392793318334
+],
+  "geometry": {"coordinates":[-1.17026338080404,52.64639279331833],"type":"Point"}
+}

--- a/data/144/482/986/9/1444829869.geojson
+++ b/data/144/482/986/9/1444829869.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"f2ee72e8a22c8f4497ad36f40260dcd4",
-    "wof:hierarchy":[],
+    "wof:geomhash":"b2800009e4666451587ac08be30191f1",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444829869,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444829869,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336890,
     "wof:name":"New Parks",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.170263380804041,
-    52.646392793318334,
-    -1.170263380804041,
-    52.646392793318334
+    -1.17026338080404,
+    52.64639279331833,
+    -1.17026338080404,
+    52.64639279331833
 ],
   "geometry": {"coordinates":[-1.17026338080404,52.64639279331833],"type":"Point"}
 }

--- a/data/144/482/988/1/1444829881.geojson
+++ b/data/144/482/988/1/1444829881.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444829881,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.15349777789,52.6403168045,-1.15349777789,52.6403168045",
+    "geom:latitude":52.640317,
+    "geom:longitude":-1.153498,
+    "iso:country":"GB",
+    "lbl:latitude":52.640317,
+    "lbl:longitude":-1.153498,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "New Found Pool"
+    ],
+    "name:eng_x_variant":[
+        "Newfoundpool"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"e5a3fc6a78d5acf10180b98a406f813d",
+    "wof:hierarchy":[],
+    "wof:id":1444829881,
+    "wof:lastmodified":1566334995,
+    "wof:name":"New Found Pool",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.153497777885975,
+    52.64031680453962,
+    -1.153497777885975,
+    52.64031680453962
+],
+  "geometry": {"coordinates":[-1.15349777788597,52.64031680453962],"type":"Point"}
+}

--- a/data/144/482/988/1/1444829881.geojson
+++ b/data/144/482/988/1/1444829881.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"e5a3fc6a78d5acf10180b98a406f813d",
-    "wof:hierarchy":[],
+    "wof:geomhash":"cf754937ed64ec60d3a994477e526f9d",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444829881,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444829881,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336891,
     "wof:name":"New Found Pool",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.153497777885975,
+    -1.15349777788597,
     52.64031680453962,
-    -1.153497777885975,
+    -1.15349777788597,
     52.64031680453962
 ],
   "geometry": {"coordinates":[-1.15349777788597,52.64031680453962],"type":"Point"}

--- a/data/144/482/990/1/1444829901.geojson
+++ b/data/144/482/990/1/1444829901.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"68e93905ff8ef3894637143739b6f4e6",
-    "wof:hierarchy":[],
+    "wof:geomhash":"ce2ac9c4b631e58f47db703056c3c1f6",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444829901,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444829901,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336894,
     "wof:name":"Stocking Farm",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.141882018867661,
-    52.662151708866894,
-    -1.141882018867661,
-    52.662151708866894
+    -1.14188201886766,
+    52.66215170886689,
+    -1.14188201886766,
+    52.66215170886689
 ],
   "geometry": {"coordinates":[-1.14188201886766,52.66215170886689],"type":"Point"}
 }

--- a/data/144/482/990/1/1444829901.geojson
+++ b/data/144/482/990/1/1444829901.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444829901,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.14188201887,52.6621517089,-1.14188201887,52.6621517089",
+    "geom:latitude":52.662152,
+    "geom:longitude":-1.141882,
+    "iso:country":"GB",
+    "lbl:latitude":52.662152,
+    "lbl:longitude":-1.141882,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Stocking Farm"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"68e93905ff8ef3894637143739b6f4e6",
+    "wof:hierarchy":[],
+    "wof:id":1444829901,
+    "wof:lastmodified":1566334995,
+    "wof:name":"Stocking Farm",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.141882018867661,
+    52.662151708866894,
+    -1.141882018867661,
+    52.662151708866894
+],
+  "geometry": {"coordinates":[-1.14188201886766,52.66215170886689],"type":"Point"}
+}

--- a/data/144/482/990/9/1444829909.geojson
+++ b/data/144/482/990/9/1444829909.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444829909,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.13648898789,52.6012280401,-1.13648898789,52.6012280401",
+    "geom:latitude":52.601228,
+    "geom:longitude":-1.136489,
+    "iso:country":"GB",
+    "lbl:latitude":52.601228,
+    "lbl:longitude":-1.136489,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Saffron Lane Estate"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"783e6e4e4f98788fc56a51c73024ce97",
+    "wof:hierarchy":[],
+    "wof:id":1444829909,
+    "wof:lastmodified":1566334995,
+    "wof:name":"Saffron Lane Estate",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.136488987894871,
+    52.60122804007875,
+    -1.136488987894871,
+    52.60122804007875
+],
+  "geometry": {"coordinates":[-1.13648898789487,52.60122804007875],"type":"Point"}
+}

--- a/data/144/482/990/9/1444829909.geojson
+++ b/data/144/482/990/9/1444829909.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"783e6e4e4f98788fc56a51c73024ce97",
-    "wof:hierarchy":[],
+    "wof:geomhash":"eac805365a66fb15cbbd555683a77c10",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444829909,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444829909,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336894,
     "wof:name":"Saffron Lane Estate",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.136488987894871,
+    -1.13648898789487,
     52.60122804007875,
-    -1.136488987894871,
+    -1.13648898789487,
     52.60122804007875
 ],
   "geometry": {"coordinates":[-1.13648898789487,52.60122804007875],"type":"Point"}

--- a/data/144/482/992/1/1444829921.geojson
+++ b/data/144/482/992/1/1444829921.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444829921,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.17062100885,52.6328074526,-1.17062100885,52.6328074526",
+    "geom:latitude":52.632807,
+    "geom:longitude":-1.170621,
+    "iso:country":"GB",
+    "lbl:latitude":52.632807,
+    "lbl:longitude":-1.170621,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Western Park"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"e8d6c25867f1c4bc978f8fa7efd671ea",
+    "wof:hierarchy":[],
+    "wof:id":1444829921,
+    "wof:lastmodified":1566334995,
+    "wof:name":"Western Park",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.17062100885267,
+    52.63280745259926,
+    -1.17062100885267,
+    52.63280745259926
+],
+  "geometry": {"coordinates":[-1.17062100885267,52.63280745259926],"type":"Point"}
+}

--- a/data/144/482/992/1/1444829921.geojson
+++ b/data/144/482/992/1/1444829921.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
     "wof:geomhash":"e8d6c25867f1c4bc978f8fa7efd671ea",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444829921,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444829921,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336895,
     "wof:name":"Western Park",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],

--- a/data/144/482/992/7/1444829927.geojson
+++ b/data/144/482/992/7/1444829927.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"c15285e68b8b21b5878271e22abfd69f",
-    "wof:hierarchy":[],
+    "wof:geomhash":"8393c8a3c3c1b3bac7fdf346a8a27620",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444829927,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444829927,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336898,
     "wof:name":"Braunstone Frith",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.200204001032355,
+    -1.20020400103235,
     52.63384928942464,
-    -1.200204001032355,
+    -1.20020400103235,
     52.63384928942464
 ],
   "geometry": {"coordinates":[-1.20020400103235,52.63384928942464],"type":"Point"}

--- a/data/144/482/992/7/1444829927.geojson
+++ b/data/144/482/992/7/1444829927.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444829927,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.20020400103,52.6338492894,-1.20020400103,52.6338492894",
+    "geom:latitude":52.633849,
+    "geom:longitude":-1.200204,
+    "iso:country":"GB",
+    "lbl:latitude":52.633849,
+    "lbl:longitude":-1.200204,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Braunstone Frith"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"c15285e68b8b21b5878271e22abfd69f",
+    "wof:hierarchy":[],
+    "wof:id":1444829927,
+    "wof:lastmodified":1566334995,
+    "wof:name":"Braunstone Frith",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.200204001032355,
+    52.63384928942464,
+    -1.200204001032355,
+    52.63384928942464
+],
+  "geometry": {"coordinates":[-1.20020400103235,52.63384928942464],"type":"Point"}
+}

--- a/data/144/482/993/7/1444829937.geojson
+++ b/data/144/482/993/7/1444829937.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
     "wof:geomhash":"7d582fd1b38fa2699fce70f2524dc249",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444829937,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444829937,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336899,
     "wof:name":"Westcotes",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],

--- a/data/144/482/993/7/1444829937.geojson
+++ b/data/144/482/993/7/1444829937.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444829937,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.1525965552,52.629473408,-1.1525965552,52.629473408",
+    "geom:latitude":52.629473,
+    "geom:longitude":-1.152597,
+    "iso:country":"GB",
+    "lbl:latitude":52.629473,
+    "lbl:longitude":-1.152597,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Westcotes"
+    ],
+    "name:eng_x_variant":[
+        "West End"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"7d582fd1b38fa2699fce70f2524dc249",
+    "wof:hierarchy":[],
+    "wof:id":1444829937,
+    "wof:lastmodified":1566334995,
+    "wof:name":"Westcotes",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.15259655520354,
+    52.62947340804695,
+    -1.15259655520354,
+    52.62947340804695
+],
+  "geometry": {"coordinates":[-1.15259655520354,52.62947340804695],"type":"Point"}
+}

--- a/data/144/482/994/7/1444829947.geojson
+++ b/data/144/482/994/7/1444829947.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444829947,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.16106518739,52.6173158857,-1.16106518739,52.6173158857",
+    "geom:latitude":52.617316,
+    "geom:longitude":-1.161065,
+    "iso:country":"GB",
+    "lbl:latitude":52.617316,
+    "lbl:longitude":-1.161065,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Rowley Fields"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"13f50c5a9b68f21e6574af37caae7896",
+    "wof:hierarchy":[],
+    "wof:id":1444829947,
+    "wof:lastmodified":1566334995,
+    "wof:name":"Rowley Fields",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.161065187394243,
+    52.61731588574713,
+    -1.161065187394243,
+    52.61731588574713
+],
+  "geometry": {"coordinates":[-1.16106518739424,52.61731588574713],"type":"Point"}
+}

--- a/data/144/482/994/7/1444829947.geojson
+++ b/data/144/482/994/7/1444829947.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"13f50c5a9b68f21e6574af37caae7896",
-    "wof:hierarchy":[],
+    "wof:geomhash":"eaabd59de8a0db6316056f0394bb6b8e",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444829947,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444829947,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336899,
     "wof:name":"Rowley Fields",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.161065187394243,
+    -1.16106518739424,
     52.61731588574713,
-    -1.161065187394243,
+    -1.16106518739424,
     52.61731588574713
 ],
   "geometry": {"coordinates":[-1.16106518739424,52.61731588574713],"type":"Point"}

--- a/data/144/482/995/9/1444829959.geojson
+++ b/data/144/482/995/9/1444829959.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444829959,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.13142497473,52.6344049256,-1.13142497473,52.6344049256",
+    "geom:latitude":52.634405,
+    "geom:longitude":-1.131425,
+    "iso:country":"GB",
+    "lbl:latitude":52.634405,
+    "lbl:longitude":-1.131425,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "City Centre"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"b6b61d925224863871d316c39c6c1435",
+    "wof:hierarchy":[],
+    "wof:id":1444829959,
+    "wof:lastmodified":1566334995,
+    "wof:name":"City Centre",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.131424974726783,
+    52.63440492558785,
+    -1.131424974726783,
+    52.63440492558785
+],
+  "geometry": {"coordinates":[-1.13142497472678,52.63440492558785],"type":"Point"}
+}

--- a/data/144/482/995/9/1444829959.geojson
+++ b/data/144/482/995/9/1444829959.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"b6b61d925224863871d316c39c6c1435",
-    "wof:hierarchy":[],
+    "wof:geomhash":"a9d02c2caddd144ce0e626d850a9fd60",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444829959,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444829959,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336900,
     "wof:name":"City Centre",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.131424974726783,
+    -1.13142497472678,
     52.63440492558785,
-    -1.131424974726783,
+    -1.13142497472678,
     52.63440492558785
 ],
   "geometry": {"coordinates":[-1.13142497472678,52.63440492558785],"type":"Point"}

--- a/data/144/482/997/1/1444829971.geojson
+++ b/data/144/482/997/1/1444829971.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444829971,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.1422968674,52.6375302475,-1.1422968674,52.6375302475",
+    "geom:latitude":52.63753,
+    "geom:longitude":-1.142297,
+    "iso:country":"GB",
+    "lbl:latitude":52.63753,
+    "lbl:longitude":-1.142297,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Black Friars"
+    ],
+    "name:eng_x_variant":[
+        "Blackfriars"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"ac54af6bb8d9ac27e5930a9d34d8a34f",
+    "wof:hierarchy":[],
+    "wof:id":1444829971,
+    "wof:lastmodified":1566334995,
+    "wof:name":"Black Friars",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.142296867404037,
+    52.63753024752644,
+    -1.142296867404037,
+    52.63753024752644
+],
+  "geometry": {"coordinates":[-1.14229686740404,52.63753024752644],"type":"Point"}
+}

--- a/data/144/482/997/1/1444829971.geojson
+++ b/data/144/482/997/1/1444829971.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"ac54af6bb8d9ac27e5930a9d34d8a34f",
-    "wof:hierarchy":[],
+    "wof:geomhash":"ce47840b7c9381912b1010fc4b402203",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444829971,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444829971,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336903,
     "wof:name":"Black Friars",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.142296867404037,
+    -1.14229686740404,
     52.63753024752644,
-    -1.142296867404037,
+    -1.14229686740404,
     52.63753024752644
 ],
   "geometry": {"coordinates":[-1.14229686740404,52.63753024752644],"type":"Point"}

--- a/data/144/482/998/1/1444829981.geojson
+++ b/data/144/482/998/1/1444829981.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444829981,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.11528879717,52.6301680216,-1.11528879717,52.6301680216",
+    "geom:latitude":52.630168,
+    "geom:longitude":-1.115289,
+    "iso:country":"GB",
+    "lbl:latitude":52.630168,
+    "lbl:longitude":-1.115289,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Highfields"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"be0491de8acee84d75b98c213f383fd5",
+    "wof:hierarchy":[],
+    "wof:id":1444829981,
+    "wof:lastmodified":1566334995,
+    "wof:name":"Highfields",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.115288797174228,
+    52.63016802161142,
+    -1.115288797174228,
+    52.63016802161142
+],
+  "geometry": {"coordinates":[-1.11528879717423,52.63016802161142],"type":"Point"}
+}

--- a/data/144/482/998/1/1444829981.geojson
+++ b/data/144/482/998/1/1444829981.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"be0491de8acee84d75b98c213f383fd5",
-    "wof:hierarchy":[],
+    "wof:geomhash":"c04199b7aed2127c3e110a08769db74c",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444829981,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444829981,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336903,
     "wof:name":"Highfields",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.115288797174228,
+    -1.11528879717423,
     52.63016802161142,
-    -1.115288797174228,
+    -1.11528879717423,
     52.63016802161142
 ],
   "geometry": {"coordinates":[-1.11528879717423,52.63016802161142],"type":"Point"}

--- a/data/144/482/999/3/1444829993.geojson
+++ b/data/144/482/999/3/1444829993.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"2bdc73e618d8429177c80a7c5e1bd125",
-    "wof:hierarchy":[],
+    "wof:geomhash":"9331b961741259e685903e6864720eae",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444829993,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444829993,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336904,
     "wof:name":"Spinney Hills",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.109852850835602,
+    -1.1098528508356,
     52.63704410144082,
-    -1.109852850835602,
+    -1.1098528508356,
     52.63704410144082
 ],
   "geometry": {"coordinates":[-1.1098528508356,52.63704410144082],"type":"Point"}

--- a/data/144/482/999/3/1444829993.geojson
+++ b/data/144/482/999/3/1444829993.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444829993,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.10985285084,52.6370441014,-1.10985285084,52.6370441014",
+    "geom:latitude":52.637044,
+    "geom:longitude":-1.109853,
+    "iso:country":"GB",
+    "lbl:latitude":52.637044,
+    "lbl:longitude":-1.109853,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Spinney Hills"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"2bdc73e618d8429177c80a7c5e1bd125",
+    "wof:hierarchy":[],
+    "wof:id":1444829993,
+    "wof:lastmodified":1566334995,
+    "wof:name":"Spinney Hills",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.109852850835602,
+    52.63704410144082,
+    -1.109852850835602,
+    52.63704410144082
+],
+  "geometry": {"coordinates":[-1.1098528508356,52.63704410144082],"type":"Point"}
+}

--- a/data/144/482/999/9/1444829999.geojson
+++ b/data/144/482/999/9/1444829999.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444829999,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.09869485572,52.63624542,-1.09869485572,52.63624542",
+    "geom:latitude":52.636245,
+    "geom:longitude":-1.098695,
+    "iso:country":"GB",
+    "lbl:latitude":52.636245,
+    "lbl:longitude":-1.098695,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "North Evington"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"f172366d2fb58b028e095287e744df5c",
+    "wof:hierarchy":[],
+    "wof:id":1444829999,
+    "wof:lastmodified":1566334995,
+    "wof:name":"North Evington",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.098694855719473,
+    52.636245419977826,
+    -1.098694855719473,
+    52.636245419977826
+],
+  "geometry": {"coordinates":[-1.09869485571947,52.63624541997783],"type":"Point"}
+}

--- a/data/144/482/999/9/1444829999.geojson
+++ b/data/144/482/999/9/1444829999.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"f172366d2fb58b028e095287e744df5c",
-    "wof:hierarchy":[],
+    "wof:geomhash":"1f19dcaac1b022f4373ca0528f77626b",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444829999,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444829999,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336905,
     "wof:name":"North Evington",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.098694855719473,
-    52.636245419977826,
-    -1.098694855719473,
-    52.636245419977826
+    -1.09869485571947,
+    52.63624541997783,
+    -1.09869485571947,
+    52.63624541997783
 ],
   "geometry": {"coordinates":[-1.09869485571947,52.63624541997783],"type":"Point"}
 }

--- a/data/144/483/000/9/1444830009.geojson
+++ b/data/144/483/000/9/1444830009.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830009,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.08221535524,52.6327054381,-1.08221535524,52.6327054381",
+    "geom:latitude":52.632705,
+    "geom:longitude":-1.082215,
+    "iso:country":"GB",
+    "lbl:latitude":52.632705,
+    "lbl:longitude":-1.082215,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Crown Hills"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"a1fd416babc111d1f558f108c72569d7",
+    "wof:hierarchy":[],
+    "wof:id":1444830009,
+    "wof:lastmodified":1566334995,
+    "wof:name":"Crown Hills",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.082215355240268,
+    52.63270543807666,
+    -1.082215355240268,
+    52.63270543807666
+],
+  "geometry": {"coordinates":[-1.08221535524027,52.63270543807666],"type":"Point"}
+}

--- a/data/144/483/000/9/1444830009.geojson
+++ b/data/144/483/000/9/1444830009.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"a1fd416babc111d1f558f108c72569d7",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d66e5712b1a0254d2fae6d28edca4d30",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830009,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444830009,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336908,
     "wof:name":"Crown Hills",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.082215355240268,
+    -1.08221535524027,
     52.63270543807666,
-    -1.082215355240268,
+    -1.08221535524027,
     52.63270543807666
 ],
   "geometry": {"coordinates":[-1.08221535524027,52.63270543807666],"type":"Point"}

--- a/data/144/483/001/9/1444830019.geojson
+++ b/data/144/483/001/9/1444830019.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830019,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.06052879037,52.6387477604,-1.06052879037,52.6387477604",
+    "geom:latitude":52.638748,
+    "geom:longitude":-1.060529,
+    "iso:country":"GB",
+    "lbl:latitude":52.638748,
+    "lbl:longitude":-1.060529,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Thurnby Lodge"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"0356a849cc23376ace307fe344cb0b65",
+    "wof:hierarchy":[],
+    "wof:id":1444830019,
+    "wof:lastmodified":1566334995,
+    "wof:name":"Thurnby Lodge",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.060528790373536,
+    52.638747760432224,
+    -1.060528790373536,
+    52.638747760432224
+],
+  "geometry": {"coordinates":[-1.06052879037354,52.63874776043222],"type":"Point"}
+}

--- a/data/144/483/001/9/1444830019.geojson
+++ b/data/144/483/001/9/1444830019.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"0356a849cc23376ace307fe344cb0b65",
-    "wof:hierarchy":[],
+    "wof:geomhash":"e167539be5a85ccf2783ee212c47b1bc",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830019,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444830019,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336909,
     "wof:name":"Thurnby Lodge",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.060528790373536,
-    52.638747760432224,
-    -1.060528790373536,
-    52.638747760432224
+    -1.06052879037354,
+    52.63874776043222,
+    -1.06052879037354,
+    52.63874776043222
 ],
   "geometry": {"coordinates":[-1.06052879037354,52.63874776043222],"type":"Point"}
 }

--- a/data/144/483/003/1/1444830031.geojson
+++ b/data/144/483/003/1/1444830031.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830031,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.0688257611,52.6311426327,-1.0688257611,52.6311426327",
+    "geom:latitude":52.631143,
+    "geom:longitude":-1.068826,
+    "iso:country":"GB",
+    "lbl:latitude":52.631143,
+    "lbl:longitude":-1.068826,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Goodwood"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"dc1110bc620fc354c32989e793501628",
+    "wof:hierarchy":[],
+    "wof:id":1444830031,
+    "wof:lastmodified":1566334995,
+    "wof:name":"Goodwood",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.068825761100914,
+    52.63114263267979,
+    -1.068825761100914,
+    52.63114263267979
+],
+  "geometry": {"coordinates":[-1.06882576110091,52.63114263267979],"type":"Point"}
+}

--- a/data/144/483/003/1/1444830031.geojson
+++ b/data/144/483/003/1/1444830031.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"dc1110bc620fc354c32989e793501628",
-    "wof:hierarchy":[],
+    "wof:geomhash":"3d87aec48b1dbb79ef2a04c09e2c5d3d",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830031,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444830031,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336909,
     "wof:name":"Goodwood",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.068825761100914,
+    -1.06882576110091,
     52.63114263267979,
-    -1.068825761100914,
+    -1.06882576110091,
     52.63114263267979
 ],
   "geometry": {"coordinates":[-1.06882576110091,52.63114263267979],"type":"Point"}

--- a/data/144/483/004/1/1444830041.geojson
+++ b/data/144/483/004/1/1444830041.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830041,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.13852031521,52.6058521577,-1.13852031521,52.6058521577",
+    "geom:latitude":52.605852,
+    "geom:longitude":-1.13852,
+    "iso:country":"GB",
+    "lbl:latitude":52.605852,
+    "lbl:longitude":-1.13852,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Aylestone Park"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"d7b944cf1ccd0f80eb488eaf1f836580",
+    "wof:hierarchy":[],
+    "wof:id":1444830041,
+    "wof:lastmodified":1566334995,
+    "wof:name":"Aylestone Park",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.138520315210886,
+    52.60585215767987,
+    -1.138520315210886,
+    52.60585215767987
+],
+  "geometry": {"coordinates":[-1.13852031521089,52.60585215767987],"type":"Point"}
+}

--- a/data/144/483/004/1/1444830041.geojson
+++ b/data/144/483/004/1/1444830041.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"d7b944cf1ccd0f80eb488eaf1f836580",
-    "wof:hierarchy":[],
+    "wof:geomhash":"67d13d6ebd347316942c983eac23db4d",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830041,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444830041,
-    "wof:lastmodified":1566334995,
+    "wof:lastmodified":1566336910,
     "wof:name":"Aylestone Park",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.138520315210886,
+    -1.13852031521089,
     52.60585215767987,
-    -1.138520315210886,
+    -1.13852031521089,
     52.60585215767987
 ],
   "geometry": {"coordinates":[-1.13852031521089,52.60585215767987],"type":"Point"}

--- a/data/144/483/005/1/1444830051.geojson
+++ b/data/144/483/005/1/1444830051.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830051,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.11860758547,52.6150251174,-1.11860758547,52.6150251174",
+    "geom:latitude":52.615025,
+    "geom:longitude":-1.118608,
+    "iso:country":"GB",
+    "lbl:latitude":52.615025,
+    "lbl:longitude":-1.118607,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Clarendon Park"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"174f6ed1667828ca540d20de7c0f0727",
+    "wof:hierarchy":[],
+    "wof:id":1444830051,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Clarendon Park",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.11860758546518,
+    52.61502511735137,
+    -1.11860758546518,
+    52.61502511735137
+],
+  "geometry": {"coordinates":[-1.11860758546518,52.61502511735137],"type":"Point"}
+}

--- a/data/144/483/005/1/1444830051.geojson
+++ b/data/144/483/005/1/1444830051.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
     "wof:geomhash":"174f6ed1667828ca540d20de7c0f0727",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830051,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444830051,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336913,
     "wof:name":"Clarendon Park",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],

--- a/data/144/483/006/1/1444830061.geojson
+++ b/data/144/483/006/1/1444830061.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830061,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.12627513083,52.610786335,-1.12627513083,52.610786335",
+    "geom:latitude":52.610786,
+    "geom:longitude":-1.126275,
+    "iso:country":"GB",
+    "lbl:latitude":52.610786,
+    "lbl:longitude":-1.126275,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Knighton Fields"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"f3323d635504783a5dd5604a5df70c01",
+    "wof:hierarchy":[],
+    "wof:id":1444830061,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Knighton Fields",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.126275130827032,
+    52.61078633499339,
+    -1.126275130827032,
+    52.61078633499339
+],
+  "geometry": {"coordinates":[-1.12627513082703,52.61078633499339],"type":"Point"}
+}

--- a/data/144/483/006/1/1444830061.geojson
+++ b/data/144/483/006/1/1444830061.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"f3323d635504783a5dd5604a5df70c01",
-    "wof:hierarchy":[],
+    "wof:geomhash":"836e3129dbed2494f924fe3110ccf412",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830061,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444830061,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336914,
     "wof:name":"Knighton Fields",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.126275130827032,
+    -1.12627513082703,
     52.61078633499339,
-    -1.126275130827032,
+    -1.12627513082703,
     52.61078633499339
 ],
   "geometry": {"coordinates":[-1.12627513082703,52.61078633499339],"type":"Point"}

--- a/data/144/483/007/7/1444830077.geojson
+++ b/data/144/483/007/7/1444830077.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"c996772baa088598a2cb337f9d3c6d4a",
-    "wof:hierarchy":[],
+    "wof:geomhash":"b85791e319bcd5413e7dd51cb219947f",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830077,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444830077,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336914,
     "wof:name":"South Knighton",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.107077657178513,
+    -1.10707765717851,
     52.60482702957112,
-    -1.107077657178513,
+    -1.10707765717851,
     52.60482702957112
 ],
   "geometry": {"coordinates":[-1.10707765717851,52.60482702957112],"type":"Point"}

--- a/data/144/483/007/7/1444830077.geojson
+++ b/data/144/483/007/7/1444830077.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830077,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.10707765718,52.6048270296,-1.10707765718,52.6048270296",
+    "geom:latitude":52.604827,
+    "geom:longitude":-1.107078,
+    "iso:country":"GB",
+    "lbl:latitude":52.604827,
+    "lbl:longitude":-1.107078,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "South Knighton"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"c996772baa088598a2cb337f9d3c6d4a",
+    "wof:hierarchy":[],
+    "wof:id":1444830077,
+    "wof:lastmodified":1566334996,
+    "wof:name":"South Knighton",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.107077657178513,
+    52.60482702957112,
+    -1.107077657178513,
+    52.60482702957112
+],
+  "geometry": {"coordinates":[-1.10707765717851,52.60482702957112],"type":"Point"}
+}

--- a/data/144/483/008/7/1444830087.geojson
+++ b/data/144/483/008/7/1444830087.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"13b871d042c4895101700a47729fd308",
-    "wof:hierarchy":[],
+    "wof:geomhash":"88878a16e1b2255e7bf9ffbc988b86a9",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830087,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444830087,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336917,
     "wof:name":"West Knighton",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.123213834731069,
-    52.601178073812946,
-    -1.123213834731069,
-    52.601178073812946
+    -1.12321383473107,
+    52.60117807381295,
+    -1.12321383473107,
+    52.60117807381295
 ],
   "geometry": {"coordinates":[-1.12321383473107,52.60117807381295],"type":"Point"}
 }

--- a/data/144/483/008/7/1444830087.geojson
+++ b/data/144/483/008/7/1444830087.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830087,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.12321383473,52.6011780738,-1.12321383473,52.6011780738",
+    "geom:latitude":52.601178,
+    "geom:longitude":-1.123214,
+    "iso:country":"GB",
+    "lbl:latitude":52.601178,
+    "lbl:longitude":-1.123214,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "West Knighton"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"13b871d042c4895101700a47729fd308",
+    "wof:hierarchy":[],
+    "wof:id":1444830087,
+    "wof:lastmodified":1566334996,
+    "wof:name":"West Knighton",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.123213834731069,
+    52.601178073812946,
+    -1.123213834731069,
+    52.601178073812946
+],
+  "geometry": {"coordinates":[-1.12321383473107,52.60117807381295],"type":"Point"}
+}

--- a/data/144/483/009/7/1444830097.geojson
+++ b/data/144/483/009/7/1444830097.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"631b56886a758492e26a043a20bf934b",
-    "wof:hierarchy":[],
+    "wof:geomhash":"58c34185cb3e5dc2838708d079861730",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830097,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444830097,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336918,
     "wof:name":"Eyres Monsell",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.146044809353302,
+    -1.1460448093533,
     52.59207173475853,
-    -1.146044809353302,
+    -1.1460448093533,
     52.59207173475853
 ],
   "geometry": {"coordinates":[-1.1460448093533,52.59207173475853],"type":"Point"}

--- a/data/144/483/009/7/1444830097.geojson
+++ b/data/144/483/009/7/1444830097.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830097,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.14604480935,52.5920717348,-1.14604480935,52.5920717348",
+    "geom:latitude":52.592072,
+    "geom:longitude":-1.146045,
+    "iso:country":"GB",
+    "lbl:latitude":52.592072,
+    "lbl:longitude":-1.146045,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Eyres Monsell"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"631b56886a758492e26a043a20bf934b",
+    "wof:hierarchy":[],
+    "wof:id":1444830097,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Eyres Monsell",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.146044809353302,
+    52.59207173475853,
+    -1.146044809353302,
+    52.59207173475853
+],
+  "geometry": {"coordinates":[-1.1460448093533,52.59207173475853],"type":"Point"}
+}

--- a/data/144/483/011/5/1444830115.geojson
+++ b/data/144/483/011/5/1444830115.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830115,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.14421375374,52.6286941253,-1.14421375374,52.6286941253",
+    "geom:latitude":52.628694,
+    "geom:longitude":-1.144214,
+    "iso:country":"GB",
+    "lbl:latitude":52.628694,
+    "lbl:longitude":-1.144214,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Bede Island"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"f8e4b0e4504af58c7d694ae1128603b7",
+    "wof:hierarchy":[],
+    "wof:id":1444830115,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Bede Island",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.144213753744501,
+    52.62869412533059,
+    -1.144213753744501,
+    52.62869412533059
+],
+  "geometry": {"coordinates":[-1.1442137537445,52.62869412533059],"type":"Point"}
+}

--- a/data/144/483/011/5/1444830115.geojson
+++ b/data/144/483/011/5/1444830115.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"f8e4b0e4504af58c7d694ae1128603b7",
-    "wof:hierarchy":[],
+    "wof:geomhash":"aedb18ca8292a9c81a097da66ef93e34",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830115,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444830115,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336918,
     "wof:name":"Bede Island",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.144213753744501,
+    -1.1442137537445,
     52.62869412533059,
-    -1.144213753744501,
+    -1.1442137537445,
     52.62869412533059
 ],
   "geometry": {"coordinates":[-1.1442137537445,52.62869412533059],"type":"Point"}

--- a/data/144/483/012/3/1444830123.geojson
+++ b/data/144/483/012/3/1444830123.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"635de0c2fe72c4fb8e319c8ccc331155",
-    "wof:hierarchy":[],
+    "wof:geomhash":"009a015d9669cfac4f4af0fe3c1d7e8d",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830123,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444830123,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336919,
     "wof:name":"Evington Valley",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.102500018156513,
-    52.623761964132825,
-    -1.102500018156513,
-    52.623761964132825
+    -1.10250001815651,
+    52.62376196413283,
+    -1.10250001815651,
+    52.62376196413283
 ],
   "geometry": {"coordinates":[-1.10250001815651,52.62376196413283],"type":"Point"}
 }

--- a/data/144/483/012/3/1444830123.geojson
+++ b/data/144/483/012/3/1444830123.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830123,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.10250001816,52.6237619641,-1.10250001816,52.6237619641",
+    "geom:latitude":52.623762,
+    "geom:longitude":-1.1025,
+    "iso:country":"GB",
+    "lbl:latitude":52.623762,
+    "lbl:longitude":-1.1025,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Evington Valley"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"635de0c2fe72c4fb8e319c8ccc331155",
+    "wof:hierarchy":[],
+    "wof:id":1444830123,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Evington Valley",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.102500018156513,
+    52.623761964132825,
+    -1.102500018156513,
+    52.623761964132825
+],
+  "geometry": {"coordinates":[-1.10250001815651,52.62376196413283],"type":"Point"}
+}

--- a/data/144/483/013/5/1444830135.geojson
+++ b/data/144/483/013/5/1444830135.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830135,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.14839084935,52.643973349,-1.14839084935,52.643973349",
+    "geom:latitude":52.643973,
+    "geom:longitude":-1.148391,
+    "iso:country":"GB",
+    "lbl:latitude":52.643973,
+    "lbl:longitude":-1.148391,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Woodgate"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"c346733ee7cb6bc9ba7da9885bbf1324",
+    "wof:hierarchy":[],
+    "wof:id":1444830135,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Woodgate",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.148390849352078,
+    52.64397334895958,
+    -1.148390849352078,
+    52.64397334895958
+],
+  "geometry": {"coordinates":[-1.14839084935208,52.64397334895958],"type":"Point"}
+}

--- a/data/144/483/013/5/1444830135.geojson
+++ b/data/144/483/013/5/1444830135.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"c346733ee7cb6bc9ba7da9885bbf1324",
-    "wof:hierarchy":[],
+    "wof:geomhash":"4f34dad378aff5fc1fdce562c49dbe6a",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830135,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444830135,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336922,
     "wof:name":"Woodgate",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.148390849352078,
+    -1.14839084935208,
     52.64397334895958,
-    -1.148390849352078,
+    -1.14839084935208,
     52.64397334895958
 ],
   "geometry": {"coordinates":[-1.14839084935208,52.64397334895958],"type":"Point"}

--- a/data/144/483/014/5/1444830145.geojson
+++ b/data/144/483/014/5/1444830145.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830145,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.12452990595,52.6297707908,-1.12452990595,52.6297707908",
+    "geom:latitude":52.629771,
+    "geom:longitude":-1.12453,
+    "iso:country":"GB",
+    "lbl:latitude":52.629771,
+    "lbl:longitude":-1.12453,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "St Peter's"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"6064e1fb4efd7331b4e59d922b5b983e",
+    "wof:hierarchy":[],
+    "wof:id":1444830145,
+    "wof:lastmodified":1566334996,
+    "wof:name":"St Peter's",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.124529905949895,
+    52.629770790829056,
+    -1.124529905949895,
+    52.629770790829056
+],
+  "geometry": {"coordinates":[-1.12452990594989,52.62977079082906],"type":"Point"}
+}

--- a/data/144/483/014/5/1444830145.geojson
+++ b/data/144/483/014/5/1444830145.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698569,
+        102191581,
+        85633159,
+        404227469,
+        101750485,
+        1360698995
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"6064e1fb4efd7331b4e59d922b5b983e",
-    "wof:hierarchy":[],
+    "wof:geomhash":"f0c3edaac95b707589767c56ced3f719",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698995,
+            "locality_id":101750485,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830145,
+            "region_id":1360698569
+        }
+    ],
     "wof:id":1444830145,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336923,
     "wof:name":"St Peter's",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750485,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.124529905949895,
-    52.629770790829056,
-    -1.124529905949895,
-    52.629770790829056
+    -1.12452990594989,
+    52.62977079082906,
+    -1.12452990594989,
+    52.62977079082906
 ],
   "geometry": {"coordinates":[-1.12452990594989,52.62977079082906],"type":"Point"}
 }

--- a/data/144/483/015/9/1444830159.geojson
+++ b/data/144/483/015/9/1444830159.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830159,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"0.14925537241,52.2003415569,0.14925537241,52.2003415569",
+    "geom:latitude":52.200342,
+    "geom:longitude":0.149255,
+    "iso:country":"GB",
+    "lbl:latitude":52.200342,
+    "lbl:longitude":0.149255,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Romsey Town"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"d7750bbb3b8dd6eb7633a10f0731cda9",
+    "wof:hierarchy":[],
+    "wof:id":1444830159,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Romsey Town",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    0.149255372409789,
+    52.20034155694918,
+    0.149255372409789,
+    52.20034155694918
+],
+  "geometry": {"coordinates":[0.14925537240979,52.20034155694918],"type":"Point"}
+}

--- a/data/144/483/015/9/1444830159.geojson
+++ b/data/144/483/015/9/1444830159.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698535,
+        102191581,
+        85633159,
+        404227469,
+        101750465,
+        1360698845
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"d7750bbb3b8dd6eb7633a10f0731cda9",
-    "wof:hierarchy":[],
+    "wof:geomhash":"a097da7738b017bb2763aaf1cda7d74f",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698845,
+            "locality_id":101750465,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830159,
+            "region_id":1360698535
+        }
+    ],
     "wof:id":1444830159,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336924,
     "wof:name":"Romsey Town",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750465,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    0.149255372409789,
+    0.14925537240979,
     52.20034155694918,
-    0.149255372409789,
+    0.14925537240979,
     52.20034155694918
 ],
   "geometry": {"coordinates":[0.14925537240979,52.20034155694918],"type":"Point"}

--- a/data/144/483/016/7/1444830167.geojson
+++ b/data/144/483/016/7/1444830167.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830167,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"0.132718651443,52.1909942633,0.132718651443,52.1909942633",
+    "geom:latitude":52.190994,
+    "geom:longitude":0.132719,
+    "iso:country":"GB",
+    "lbl:latitude":52.190994,
+    "lbl:longitude":0.132719,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Newtown"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"2a3aab749c2d611904029b3e6323285f",
+    "wof:hierarchy":[],
+    "wof:id":1444830167,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Newtown",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    0.132718651442809,
+    52.190994263291195,
+    0.132718651442809,
+    52.190994263291195
+],
+  "geometry": {"coordinates":[0.13271865144281,52.19099426329119],"type":"Point"}
+}

--- a/data/144/483/016/7/1444830167.geojson
+++ b/data/144/483/016/7/1444830167.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698535,
+        102191581,
+        85633159,
+        404227469,
+        101750465,
+        1360698845
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"2a3aab749c2d611904029b3e6323285f",
-    "wof:hierarchy":[],
+    "wof:geomhash":"ebbda4341df570efcbc37da5a55b9fac",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698845,
+            "locality_id":101750465,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830167,
+            "region_id":1360698535
+        }
+    ],
     "wof:id":1444830167,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336924,
     "wof:name":"Newtown",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750465,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    0.132718651442809,
-    52.190994263291195,
-    0.132718651442809,
-    52.190994263291195
+    0.13271865144281,
+    52.19099426329119,
+    0.13271865144281,
+    52.19099426329119
 ],
   "geometry": {"coordinates":[0.13271865144281,52.19099426329119],"type":"Point"}
 }

--- a/data/144/483/017/7/1444830177.geojson
+++ b/data/144/483/017/7/1444830177.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698535,
+        102191581,
+        85633159,
+        404227469,
+        101750465,
+        1360698845
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"42617bca1493399c6474ed656f098b6b",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d4f91a49598b0673b23768bb71547620",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698845,
+            "locality_id":101750465,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830177,
+            "region_id":1360698535
+        }
+    ],
     "wof:id":1444830177,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336927,
     "wof:name":"Kings Hedges",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750465,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    0.132432549003934,
+    0.13243254900393,
     52.22951069427657,
-    0.132432549003934,
+    0.13243254900393,
     52.22951069427657
 ],
   "geometry": {"coordinates":[0.13243254900393,52.22951069427657],"type":"Point"}

--- a/data/144/483/017/7/1444830177.geojson
+++ b/data/144/483/017/7/1444830177.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830177,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"0.132432549004,52.2295106943,0.132432549004,52.2295106943",
+    "geom:latitude":52.229511,
+    "geom:longitude":0.132433,
+    "iso:country":"GB",
+    "lbl:latitude":52.229511,
+    "lbl:longitude":0.132433,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Kings Hedges"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"42617bca1493399c6474ed656f098b6b",
+    "wof:hierarchy":[],
+    "wof:id":1444830177,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Kings Hedges",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    0.132432549003934,
+    52.22951069427657,
+    0.132432549003934,
+    52.22951069427657
+],
+  "geometry": {"coordinates":[0.13243254900393,52.22951069427657],"type":"Point"}
+}

--- a/data/144/483/018/7/1444830187.geojson
+++ b/data/144/483/018/7/1444830187.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830187,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"0.118814072913,52.2247439718,0.118814072913,52.2247439718",
+    "geom:latitude":52.224744,
+    "geom:longitude":0.118814,
+    "iso:country":"GB",
+    "lbl:latitude":52.224744,
+    "lbl:longitude":0.118814,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Arbury"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"e50fcee4cede31081e680309d6166fe9",
+    "wof:hierarchy":[],
+    "wof:id":1444830187,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Arbury",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    0.118814072913479,
+    52.22474397180118,
+    0.118814072913479,
+    52.22474397180118
+],
+  "geometry": {"coordinates":[0.11881407291348,52.22474397180118],"type":"Point"}
+}

--- a/data/144/483/018/7/1444830187.geojson
+++ b/data/144/483/018/7/1444830187.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698535,
+        102191581,
+        85633159,
+        404227469,
+        101750465,
+        1360698845
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"e50fcee4cede31081e680309d6166fe9",
-    "wof:hierarchy":[],
+    "wof:geomhash":"e47aa83781330368c8951fc92a6ed290",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698845,
+            "locality_id":101750465,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830187,
+            "region_id":1360698535
+        }
+    ],
     "wof:id":1444830187,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336928,
     "wof:name":"Arbury",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750465,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    0.118814072913479,
+    0.11881407291348,
     52.22474397180118,
-    0.118814072913479,
+    0.11881407291348,
     52.22474397180118
 ],
   "geometry": {"coordinates":[0.11881407291348,52.22474397180118],"type":"Point"}

--- a/data/144/483/019/9/1444830199.geojson
+++ b/data/144/483/019/9/1444830199.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830199,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"0.0840240163463,52.2127548051,0.0840240163463,52.2127548051",
+    "geom:latitude":52.212755,
+    "geom:longitude":0.084024,
+    "iso:country":"GB",
+    "lbl:latitude":52.212755,
+    "lbl:longitude":0.084024,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "High Cross"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"3b52b19db3e500a3175de573aa6bd4ba",
+    "wof:hierarchy":[],
+    "wof:id":1444830199,
+    "wof:lastmodified":1566334996,
+    "wof:name":"High Cross",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    0.084024016346268,
+    52.212754805108425,
+    0.084024016346268,
+    52.212754805108425
+],
+  "geometry": {"coordinates":[0.08402401634627,52.21275480510842],"type":"Point"}
+}

--- a/data/144/483/019/9/1444830199.geojson
+++ b/data/144/483/019/9/1444830199.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698535,
+        102191581,
+        85633159,
+        404227469,
+        101750465,
+        1360698845
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"3b52b19db3e500a3175de573aa6bd4ba",
-    "wof:hierarchy":[],
+    "wof:geomhash":"35f7bbb6023cbeb08f651d0698d2ec2c",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698845,
+            "locality_id":101750465,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830199,
+            "region_id":1360698535
+        }
+    ],
     "wof:id":1444830199,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336929,
     "wof:name":"High Cross",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750465,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    0.084024016346268,
-    52.212754805108425,
-    0.084024016346268,
-    52.212754805108425
+    0.08402401634627,
+    52.21275480510842,
+    0.08402401634627,
+    52.21275480510842
 ],
   "geometry": {"coordinates":[0.08402401634627,52.21275480510842],"type":"Point"}
 }

--- a/data/144/483/021/1/1444830211.geojson
+++ b/data/144/483/021/1/1444830211.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698535,
+        102191581,
+        85633159,
+        404227469,
+        101750465,
+        1360698845
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"f4b3016fd4c2c152f2afb032f8463fea",
-    "wof:hierarchy":[],
+    "wof:geomhash":"6da4f0193dca133e7fdfa38418d73e55",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698845,
+            "locality_id":101750465,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830211,
+            "region_id":1360698535
+        }
+    ],
     "wof:id":1444830211,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336932,
     "wof:name":"Castle",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750465,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    0.105310037798575,
+    0.10531003779858,
     52.22034481431953,
-    0.105310037798575,
+    0.10531003779858,
     52.22034481431953
 ],
   "geometry": {"coordinates":[0.10531003779858,52.22034481431953],"type":"Point"}

--- a/data/144/483/021/1/1444830211.geojson
+++ b/data/144/483/021/1/1444830211.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830211,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"0.105310037799,52.2203448143,0.105310037799,52.2203448143",
+    "geom:latitude":52.220345,
+    "geom:longitude":0.10531,
+    "iso:country":"GB",
+    "lbl:latitude":52.220345,
+    "lbl:longitude":0.10531,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Castle"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"f4b3016fd4c2c152f2afb032f8463fea",
+    "wof:hierarchy":[],
+    "wof:id":1444830211,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Castle",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    0.105310037798575,
+    52.22034481431953,
+    0.105310037798575,
+    52.22034481431953
+],
+  "geometry": {"coordinates":[0.10531003779858,52.22034481431953],"type":"Point"}
+}

--- a/data/144/483/022/1/1444830221.geojson
+++ b/data/144/483/022/1/1444830221.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698535,
+        102191581,
+        85633159,
+        404227469,
+        101750465,
+        1360698845
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"f1fa927075834bc138042b90548ba13b",
-    "wof:hierarchy":[],
+    "wof:geomhash":"3a22924614e0fd3cf0217e299dae72af",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698845,
+            "locality_id":101750465,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830221,
+            "region_id":1360698535
+        }
+    ],
     "wof:id":1444830221,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336932,
     "wof:name":"Queen Edith's",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750465,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -46,9 +63,9 @@
 },
   "bbox": [
     0.15188751484744,
-    52.178469676213446,
+    52.17846967621345,
     0.15188751484744,
-    52.178469676213446
+    52.17846967621345
 ],
   "geometry": {"coordinates":[0.15188751484744,52.17846967621345],"type":"Point"}
 }

--- a/data/144/483/022/1/1444830221.geojson
+++ b/data/144/483/022/1/1444830221.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444830221,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"0.151887514847,52.1784696762,0.151887514847,52.1784696762",
+    "geom:latitude":52.17847,
+    "geom:longitude":0.151888,
+    "iso:country":"GB",
+    "lbl:latitude":52.17847,
+    "lbl:longitude":0.151888,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Queen Edith's"
+    ],
+    "name:eng_x_variant":[
+        "Queen Ediths"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"f1fa927075834bc138042b90548ba13b",
+    "wof:hierarchy":[],
+    "wof:id":1444830221,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Queen Edith's",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    0.15188751484744,
+    52.178469676213446,
+    0.15188751484744,
+    52.178469676213446
+],
+  "geometry": {"coordinates":[0.15188751484744,52.17846967621345],"type":"Point"}
+}

--- a/data/144/483/023/1/1444830231.geojson
+++ b/data/144/483/023/1/1444830231.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830231,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.19839544366,51.7577142003,-1.19839544366,51.7577142003",
+    "geom:latitude":51.757714,
+    "geom:longitude":-1.198395,
+    "iso:country":"GB",
+    "lbl:latitude":51.757714,
+    "lbl:longitude":-1.198395,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Headington Quarry"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"141a4853df796ebad07a16b7bff75a15",
+    "wof:hierarchy":[],
+    "wof:id":1444830231,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Headington Quarry",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.198395443656498,
+    51.75771420029493,
+    -1.198395443656498,
+    51.75771420029493
+],
+  "geometry": {"coordinates":[-1.1983954436565,51.75771420029493],"type":"Point"}
+}

--- a/data/144/483/023/1/1444830231.geojson
+++ b/data/144/483/023/1/1444830231.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"141a4853df796ebad07a16b7bff75a15",
-    "wof:hierarchy":[],
+    "wof:geomhash":"0bf4ca9f4e243cd5d35fa03ddb82cd7f",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830231,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830231,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336933,
     "wof:name":"Headington Quarry",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.198395443656498,
+    -1.1983954436565,
     51.75771420029493,
-    -1.198395443656498,
+    -1.1983954436565,
     51.75771420029493
 ],
   "geometry": {"coordinates":[-1.1983954436565,51.75771420029493],"type":"Point"}

--- a/data/144/483/024/1/1444830241.geojson
+++ b/data/144/483/024/1/1444830241.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830241,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.19324559976,51.7652223632,-1.19324559976,51.7652223632",
+    "geom:latitude":51.765222,
+    "geom:longitude":-1.193246,
+    "iso:country":"GB",
+    "lbl:latitude":51.765222,
+    "lbl:longitude":-1.193245,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Barton"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"a8327d96e4f4fc8495fb05862095e931",
+    "wof:hierarchy":[],
+    "wof:id":1444830241,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Barton",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.19324559975675,
+    51.765222363153555,
+    -1.19324559975675,
+    51.765222363153555
+],
+  "geometry": {"coordinates":[-1.19324559975675,51.76522236315355],"type":"Point"}
+}

--- a/data/144/483/024/1/1444830241.geojson
+++ b/data/144/483/024/1/1444830241.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"a8327d96e4f4fc8495fb05862095e931",
-    "wof:hierarchy":[],
+    "wof:geomhash":"a30ff39e2dad5ab29098e90010ee451b",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830241,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830241,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336936,
     "wof:name":"Barton",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -43,9 +60,9 @@
 },
   "bbox": [
     -1.19324559975675,
-    51.765222363153555,
+    51.76522236315355,
     -1.19324559975675,
-    51.765222363153555
+    51.76522236315355
 ],
   "geometry": {"coordinates":[-1.19324559975675,51.76522236315355],"type":"Point"}
 }

--- a/data/144/483/024/7/1444830247.geojson
+++ b/data/144/483/024/7/1444830247.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"809a65e65cc31108f857870929642fa3",
-    "wof:hierarchy":[],
+    "wof:geomhash":"1a9cdb4be62c2cbd7c2feeddbe6575f3",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830247,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830247,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336937,
     "wof:name":"New Marston",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.235130996808028,
+    -1.23513099680803,
     51.76316836719336,
-    -1.235130996808028,
+    -1.23513099680803,
     51.76316836719336
 ],
   "geometry": {"coordinates":[-1.23513099680803,51.76316836719336],"type":"Point"}

--- a/data/144/483/024/7/1444830247.geojson
+++ b/data/144/483/024/7/1444830247.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830247,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.23513099681,51.7631683672,-1.23513099681,51.7631683672",
+    "geom:latitude":51.763168,
+    "geom:longitude":-1.235131,
+    "iso:country":"GB",
+    "lbl:latitude":51.763168,
+    "lbl:longitude":-1.235131,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "New Marston"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"809a65e65cc31108f857870929642fa3",
+    "wof:hierarchy":[],
+    "wof:id":1444830247,
+    "wof:lastmodified":1566334996,
+    "wof:name":"New Marston",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.235130996808028,
+    51.76316836719336,
+    -1.235130996808028,
+    51.76316836719336
+],
+  "geometry": {"coordinates":[-1.23513099680803,51.76316836719336],"type":"Point"}
+}

--- a/data/144/483/025/1/1444830251.geojson
+++ b/data/144/483/025/1/1444830251.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830251,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.29212260263,51.7839873082,-1.29212260263,51.7839873082",
+    "geom:latitude":51.783987,
+    "geom:longitude":-1.292123,
+    "iso:country":"GB",
+    "lbl:latitude":51.783987,
+    "lbl:longitude":-1.292123,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Wolvercote"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"2262208c6de16ba6fd5adc55b18fc469",
+    "wof:hierarchy":[],
+    "wof:id":1444830251,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Wolvercote",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.292122602631897,
+    51.783987308162914,
+    -1.292122602631897,
+    51.783987308162914
+],
+  "geometry": {"coordinates":[-1.2921226026319,51.78398730816291],"type":"Point"}
+}

--- a/data/144/483/025/1/1444830251.geojson
+++ b/data/144/483/025/1/1444830251.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"2262208c6de16ba6fd5adc55b18fc469",
-    "wof:hierarchy":[],
+    "wof:geomhash":"5c9914d0097a39cbbb5708415beea4f7",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830251,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830251,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336938,
     "wof:name":"Wolvercote",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.292122602631897,
-    51.783987308162914,
-    -1.292122602631897,
-    51.783987308162914
+    -1.2921226026319,
+    51.78398730816291,
+    -1.2921226026319,
+    51.78398730816291
 ],
   "geometry": {"coordinates":[-1.2921226026319,51.78398730816291],"type":"Point"}
 }

--- a/data/144/483/025/7/1444830257.geojson
+++ b/data/144/483/025/7/1444830257.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830257,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.26534341435,51.7900046001,-1.26534341435,51.7900046001",
+    "geom:latitude":51.790005,
+    "geom:longitude":-1.265343,
+    "iso:country":"GB",
+    "lbl:latitude":51.790005,
+    "lbl:longitude":-1.265343,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Cutteslowe"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"b819d40a84108f4ba5c37086d2e986b8",
+    "wof:hierarchy":[],
+    "wof:id":1444830257,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Cutteslowe",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.265343414353212,
+    51.79000460010206,
+    -1.265343414353212,
+    51.79000460010206
+],
+  "geometry": {"coordinates":[-1.26534341435321,51.79000460010206],"type":"Point"}
+}

--- a/data/144/483/025/7/1444830257.geojson
+++ b/data/144/483/025/7/1444830257.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"b819d40a84108f4ba5c37086d2e986b8",
-    "wof:hierarchy":[],
+    "wof:geomhash":"c43d0a757873a4cc5ea1d11097aabbce",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830257,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830257,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336938,
     "wof:name":"Cutteslowe",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.265343414353212,
+    -1.26534341435321,
     51.79000460010206,
-    -1.265343414353212,
+    -1.26534341435321,
     51.79000460010206
 ],
   "geometry": {"coordinates":[-1.26534341435321,51.79000460010206],"type":"Point"}

--- a/data/144/483/026/3/1444830263.geojson
+++ b/data/144/483/026/3/1444830263.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830263,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.26397012265,51.7828545517,-1.26397012265,51.7828545517",
+    "geom:latitude":51.782855,
+    "geom:longitude":-1.26397,
+    "iso:country":"GB",
+    "lbl:latitude":51.782854,
+    "lbl:longitude":-1.26397,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Sunnymead"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"4b5126180876d08e2e512daafef45208",
+    "wof:hierarchy":[],
+    "wof:id":1444830263,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Sunnymead",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.263970122646613,
+    51.78285455167656,
+    -1.263970122646613,
+    51.78285455167656
+],
+  "geometry": {"coordinates":[-1.26397012264661,51.78285455167656],"type":"Point"}
+}

--- a/data/144/483/026/3/1444830263.geojson
+++ b/data/144/483/026/3/1444830263.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"4b5126180876d08e2e512daafef45208",
-    "wof:hierarchy":[],
+    "wof:geomhash":"7e74282477d070dfe8caf95a4240f566",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830263,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830263,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336941,
     "wof:name":"Sunnymead",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.263970122646613,
+    -1.26397012264661,
     51.78285455167656,
-    -1.263970122646613,
+    -1.26397012264661,
     51.78285455167656
 ],
   "geometry": {"coordinates":[-1.26397012264661,51.78285455167656],"type":"Point"}

--- a/data/144/483/026/5/1444830265.geojson
+++ b/data/144/483/026/5/1444830265.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"713307abea08b783a06a8d33708c8fc7",
-    "wof:hierarchy":[],
+    "wof:geomhash":"ad2e576902cf5c058f0875e59ceb509c",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830265,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830265,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336942,
     "wof:name":"Binsey",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.289261578243149,
+    -1.28926157824315,
     51.76415996311754,
-    -1.289261578243149,
+    -1.28926157824315,
     51.76415996311754
 ],
   "geometry": {"coordinates":[-1.28926157824315,51.76415996311754],"type":"Point"}

--- a/data/144/483/026/5/1444830265.geojson
+++ b/data/144/483/026/5/1444830265.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830265,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.28926157824,51.7641599631,-1.28926157824,51.7641599631",
+    "geom:latitude":51.76416,
+    "geom:longitude":-1.289262,
+    "iso:country":"GB",
+    "lbl:latitude":51.76416,
+    "lbl:longitude":-1.289262,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Binsey"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"713307abea08b783a06a8d33708c8fc7",
+    "wof:hierarchy":[],
+    "wof:id":1444830265,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Binsey",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.289261578243149,
+    51.76415996311754,
+    -1.289261578243149,
+    51.76415996311754
+],
+  "geometry": {"coordinates":[-1.28926157824315,51.76415996311754],"type":"Point"}
+}

--- a/data/144/483/026/7/1444830267.geojson
+++ b/data/144/483/026/7/1444830267.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"60df034af18e324420b4ca84a3bacb8c",
-    "wof:hierarchy":[],
+    "wof:geomhash":"2becf2bee5f2d6759d76391378269bef",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830267,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830267,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336943,
     "wof:name":"Park Town",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.259464009234332,
+    -1.25946400923433,
     51.76638212195575,
-    -1.259464009234332,
+    -1.25946400923433,
     51.76638212195575
 ],
   "geometry": {"coordinates":[-1.25946400923433,51.76638212195575],"type":"Point"}

--- a/data/144/483/026/7/1444830267.geojson
+++ b/data/144/483/026/7/1444830267.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444830267,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.25946400923,51.766382122,-1.25946400923,51.766382122",
+    "geom:latitude":51.766382,
+    "geom:longitude":-1.259464,
+    "iso:country":"GB",
+    "lbl:latitude":51.766382,
+    "lbl:longitude":-1.259464,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Park Town"
+    ],
+    "name:eng_x_variant":[
+        "Parktown"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"60df034af18e324420b4ca84a3bacb8c",
+    "wof:hierarchy":[],
+    "wof:id":1444830267,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Park Town",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.259464009234332,
+    51.76638212195575,
+    -1.259464009234332,
+    51.76638212195575
+],
+  "geometry": {"coordinates":[-1.25946400923433,51.76638212195575],"type":"Point"}
+}

--- a/data/144/483/027/1/1444830271.geojson
+++ b/data/144/483/027/1/1444830271.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"cb7ce7f75fd3a54659dc6ec33915686a",
-    "wof:hierarchy":[],
+    "wof:geomhash":"a7766580390dd376152c9b6406bd9a35",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830271,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830271,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336943,
     "wof:name":"Walton Manor",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.267975556790861,
+    -1.26797555679086,
     51.76281422051365,
-    -1.267975556790861,
+    -1.26797555679086,
     51.76281422051365
 ],
   "geometry": {"coordinates":[-1.26797555679086,51.76281422051365],"type":"Point"}

--- a/data/144/483/027/1/1444830271.geojson
+++ b/data/144/483/027/1/1444830271.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830271,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.26797555679,51.7628142205,-1.26797555679,51.7628142205",
+    "geom:latitude":51.762814,
+    "geom:longitude":-1.267976,
+    "iso:country":"GB",
+    "lbl:latitude":51.762814,
+    "lbl:longitude":-1.267975,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Walton Manor"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"cb7ce7f75fd3a54659dc6ec33915686a",
+    "wof:hierarchy":[],
+    "wof:id":1444830271,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Walton Manor",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.267975556790861,
+    51.76281422051365,
+    -1.267975556790861,
+    51.76281422051365
+],
+  "geometry": {"coordinates":[-1.26797555679086,51.76281422051365],"type":"Point"}
+}

--- a/data/144/483/027/7/1444830277.geojson
+++ b/data/144/483/027/7/1444830277.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"9662597a7038ab10d9d2dc006d8bca30",
-    "wof:hierarchy":[],
+    "wof:geomhash":"c909135279026486ca0d844a5bcae24e",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830277,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830277,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336946,
     "wof:name":"Norham Manor",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.261109098257865,
+    -1.26110909825786,
     51.76182259503137,
-    -1.261109098257865,
+    -1.26110909825786,
     51.76182259503137
 ],
   "geometry": {"coordinates":[-1.26110909825786,51.76182259503137],"type":"Point"}

--- a/data/144/483/027/7/1444830277.geojson
+++ b/data/144/483/027/7/1444830277.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830277,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.26110909826,51.761822595,-1.26110909826,51.761822595",
+    "geom:latitude":51.761823,
+    "geom:longitude":-1.261109,
+    "iso:country":"GB",
+    "lbl:latitude":51.761823,
+    "lbl:longitude":-1.261109,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Norham Manor"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"9662597a7038ab10d9d2dc006d8bca30",
+    "wof:hierarchy":[],
+    "wof:id":1444830277,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Norham Manor",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.261109098257865,
+    51.76182259503137,
+    -1.261109098257865,
+    51.76182259503137
+],
+  "geometry": {"coordinates":[-1.26110909825786,51.76182259503137],"type":"Point"}
+}

--- a/data/144/483/028/1/1444830281.geojson
+++ b/data/144/483/028/1/1444830281.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"57f2d1123dcae22d59475dc501309465",
-    "wof:hierarchy":[],
+    "wof:geomhash":"cd103e91d6f9fe0ac335f2f5fa1a6aea",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830281,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830281,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336947,
     "wof:name":"Jericho",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.266645180450096,
+    -1.2666451804501,
     51.75961792105674,
-    -1.266645180450096,
+    -1.2666451804501,
     51.75961792105674
 ],
   "geometry": {"coordinates":[-1.2666451804501,51.75961792105674],"type":"Point"}

--- a/data/144/483/028/1/1444830281.geojson
+++ b/data/144/483/028/1/1444830281.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830281,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.26664518045,51.7596179211,-1.26664518045,51.7596179211",
+    "geom:latitude":51.759618,
+    "geom:longitude":-1.266645,
+    "iso:country":"GB",
+    "lbl:latitude":51.759618,
+    "lbl:longitude":-1.266645,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Jericho"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"57f2d1123dcae22d59475dc501309465",
+    "wof:hierarchy":[],
+    "wof:id":1444830281,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Jericho",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.266645180450096,
+    51.75961792105674,
+    -1.266645180450096,
+    51.75961792105674
+],
+  "geometry": {"coordinates":[-1.2666451804501,51.75961792105674],"type":"Point"}
+}

--- a/data/144/483/028/7/1444830287.geojson
+++ b/data/144/483/028/7/1444830287.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"3f23395718a3f51935067314bf8603f5",
-    "wof:hierarchy":[],
+    "wof:geomhash":"0ab5f27b507e1d64486cce97635cf30f",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830287,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830287,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336948,
     "wof:name":"Osney",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.273640385080593,
-    51.751134677557616,
-    -1.273640385080593,
-    51.751134677557616
+    -1.27364038508059,
+    51.75113467755762,
+    -1.27364038508059,
+    51.75113467755762
 ],
   "geometry": {"coordinates":[-1.27364038508059,51.75113467755762],"type":"Point"}
 }

--- a/data/144/483/028/7/1444830287.geojson
+++ b/data/144/483/028/7/1444830287.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830287,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.27364038508,51.7511346776,-1.27364038508,51.7511346776",
+    "geom:latitude":51.751135,
+    "geom:longitude":-1.27364,
+    "iso:country":"GB",
+    "lbl:latitude":51.751135,
+    "lbl:longitude":-1.27364,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Osney"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"3f23395718a3f51935067314bf8603f5",
+    "wof:hierarchy":[],
+    "wof:id":1444830287,
+    "wof:lastmodified":1566334996,
+    "wof:name":"Osney",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.273640385080593,
+    51.751134677557616,
+    -1.273640385080593,
+    51.751134677557616
+],
+  "geometry": {"coordinates":[-1.27364038508059,51.75113467755762],"type":"Point"}
+}

--- a/data/144/483/029/5/1444830295.geojson
+++ b/data/144/483/029/5/1444830295.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"7a421b019df7362aa656b70ad2001df9",
-    "wof:hierarchy":[],
+    "wof:geomhash":"e275f1259f21de43fd2eff886a728cd5",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830295,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830295,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336948,
     "wof:name":"North Oxford",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.263626799719965,
+    -1.26362679971997,
     51.76997629703955,
-    -1.263626799719965,
+    -1.26362679971997,
     51.76997629703955
 ],
   "geometry": {"coordinates":[-1.26362679971997,51.76997629703955],"type":"Point"}

--- a/data/144/483/029/5/1444830295.geojson
+++ b/data/144/483/029/5/1444830295.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830295,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.26362679972,51.769976297,-1.26362679972,51.769976297",
+    "geom:latitude":51.769976,
+    "geom:longitude":-1.263627,
+    "iso:country":"GB",
+    "lbl:latitude":51.769976,
+    "lbl:longitude":-1.263627,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "North Oxford"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"7a421b019df7362aa656b70ad2001df9",
+    "wof:hierarchy":[],
+    "wof:id":1444830295,
+    "wof:lastmodified":1566334996,
+    "wof:name":"North Oxford",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.263626799719965,
+    51.76997629703955,
+    -1.263626799719965,
+    51.76997629703955
+],
+  "geometry": {"coordinates":[-1.26362679971997,51.76997629703955],"type":"Point"}
+}

--- a/data/144/483/030/1/1444830301.geojson
+++ b/data/144/483/030/1/1444830301.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830301,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.2534415529,51.7382030785,-1.2534415529,51.7382030785",
+    "geom:latitude":51.738203,
+    "geom:longitude":-1.253442,
+    "iso:country":"GB",
+    "lbl:latitude":51.738203,
+    "lbl:longitude":-1.253442,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "New Hinksey"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"8e93938069948348f340ecfd326840a9",
+    "wof:hierarchy":[],
+    "wof:id":1444830301,
+    "wof:lastmodified":1566334996,
+    "wof:name":"New Hinksey",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.253441552896011,
+    51.738203078539286,
+    -1.253441552896011,
+    51.738203078539286
+],
+  "geometry": {"coordinates":[-1.25344155289601,51.73820307853929],"type":"Point"}
+}

--- a/data/144/483/030/1/1444830301.geojson
+++ b/data/144/483/030/1/1444830301.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"8e93938069948348f340ecfd326840a9",
-    "wof:hierarchy":[],
+    "wof:geomhash":"c36e5fb034504df1c57667501eb4bce2",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830301,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830301,
-    "wof:lastmodified":1566334996,
+    "wof:lastmodified":1566336951,
     "wof:name":"New Hinksey",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.253441552896011,
-    51.738203078539286,
-    -1.253441552896011,
-    51.738203078539286
+    -1.25344155289601,
+    51.73820307853929,
+    -1.25344155289601,
+    51.73820307853929
 ],
   "geometry": {"coordinates":[-1.25344155289601,51.73820307853929],"type":"Point"}
 }

--- a/data/144/483/031/1/1444830311.geojson
+++ b/data/144/483/031/1/1444830311.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"c3101365e49f777fb0b5eb0df0d87bb5",
-    "wof:hierarchy":[],
+    "wof:geomhash":"fb70b4eb3ea1e1e98db7aab8c0722767",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830311,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830311,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566336952,
     "wof:name":"Grandpont",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.258934719722413,
+    -1.25893471972241,
     51.7445807680632,
-    -1.258934719722413,
+    -1.25893471972241,
     51.7445807680632
 ],
   "geometry": {"coordinates":[-1.25893471972241,51.7445807680632],"type":"Point"}

--- a/data/144/483/031/1/1444830311.geojson
+++ b/data/144/483/031/1/1444830311.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830311,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.25893471972,51.7445807681,-1.25893471972,51.7445807681",
+    "geom:latitude":51.744581,
+    "geom:longitude":-1.258935,
+    "iso:country":"GB",
+    "lbl:latitude":51.744581,
+    "lbl:longitude":-1.258935,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Grandpont"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"c3101365e49f777fb0b5eb0df0d87bb5",
+    "wof:hierarchy":[],
+    "wof:id":1444830311,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Grandpont",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.258934719722413,
+    51.7445807680632,
+    -1.258934719722413,
+    51.7445807680632
+],
+  "geometry": {"coordinates":[-1.25893471972241,51.7445807680632],"type":"Point"}
+}

--- a/data/144/483/031/9/1444830319.geojson
+++ b/data/144/483/031/9/1444830319.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830319,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.20955343877,51.7543227221,-1.20955343877,51.7543227221",
+    "geom:latitude":51.754323,
+    "geom:longitude":-1.209553,
+    "iso:country":"GB",
+    "lbl:latitude":51.754323,
+    "lbl:longitude":-1.209553,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "New Headington"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"0ba9f61b38fcb8920cbe1eaf6a93e7b0",
+    "wof:hierarchy":[],
+    "wof:id":1444830319,
+    "wof:lastmodified":1566334997,
+    "wof:name":"New Headington",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.209553438772572,
+    51.75432272214345,
+    -1.209553438772572,
+    51.75432272214345
+],
+  "geometry": {"coordinates":[-1.20955343877257,51.75432272214345],"type":"Point"}
+}

--- a/data/144/483/031/9/1444830319.geojson
+++ b/data/144/483/031/9/1444830319.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"0ba9f61b38fcb8920cbe1eaf6a93e7b0",
-    "wof:hierarchy":[],
+    "wof:geomhash":"2b81cd4fe293779ae190f00a1465b03a",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830319,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830319,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566336953,
     "wof:name":"New Headington",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.209553438772572,
+    -1.20955343877257,
     51.75432272214345,
-    -1.209553438772572,
+    -1.20955343877257,
     51.75432272214345
 ],
   "geometry": {"coordinates":[-1.20955343877257,51.75432272214345],"type":"Point"}

--- a/data/144/483/032/5/1444830325.geojson
+++ b/data/144/483/032/5/1444830325.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830325,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.2225424895,51.7211560576,-1.2225424895,51.7211560576",
+    "geom:latitude":51.721156,
+    "geom:longitude":-1.222542,
+    "iso:country":"GB",
+    "lbl:latitude":51.721156,
+    "lbl:longitude":-1.222542,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Littlemore"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"86a212bd483b235299f2375b7ed99373",
+    "wof:hierarchy":[],
+    "wof:id":1444830325,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Littlemore",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.222542489497501,
+    51.721156057593035,
+    -1.222542489497501,
+    51.721156057593035
+],
+  "geometry": {"coordinates":[-1.2225424894975,51.72115605759303],"type":"Point"}
+}

--- a/data/144/483/032/5/1444830325.geojson
+++ b/data/144/483/032/5/1444830325.geojson
@@ -26,15 +26,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        404429233,
+        85633159,
+        404227469,
+        1125987387,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"86a212bd483b235299f2375b7ed99373",
-    "wof:hierarchy":[],
+    "wof:geomhash":"75b52793854c11ab735095daf07044f0",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "localadmin_id":404429233,
+            "locality_id":1125987387,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830325,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830325,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566336956,
     "wof:name":"Littlemore",
-    "wof:parent_id":-1,
+    "wof:parent_id":1125987387,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +61,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.222542489497501,
-    51.721156057593035,
-    -1.222542489497501,
-    51.721156057593035
+    -1.2225424894975,
+    51.72115605759303,
+    -1.2225424894975,
+    51.72115605759303
 ],
   "geometry": {"coordinates":[-1.2225424894975,51.72115605759303],"type":"Point"}
 }

--- a/data/144/483/033/5/1444830335.geojson
+++ b/data/144/483/033/5/1444830335.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"fd9bb117dd726cfd211d136bdfa87fac",
-    "wof:hierarchy":[],
+    "wof:geomhash":"bde9a499869d4182d08fe788fe2ff11f",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830335,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830335,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566336957,
     "wof:name":"Rose Hill",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.220310890474275,
+    -1.22031089047427,
     51.72952088785097,
-    -1.220310890474275,
+    -1.22031089047427,
     51.72952088785097
 ],
   "geometry": {"coordinates":[-1.22031089047427,51.72952088785097],"type":"Point"}

--- a/data/144/483/033/5/1444830335.geojson
+++ b/data/144/483/033/5/1444830335.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830335,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.22031089047,51.7295208879,-1.22031089047,51.7295208879",
+    "geom:latitude":51.729521,
+    "geom:longitude":-1.220311,
+    "iso:country":"GB",
+    "lbl:latitude":51.729521,
+    "lbl:longitude":-1.220311,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Rose Hill"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"fd9bb117dd726cfd211d136bdfa87fac",
+    "wof:hierarchy":[],
+    "wof:id":1444830335,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Rose Hill",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.220310890474275,
+    51.72952088785097,
+    -1.220310890474275,
+    51.72952088785097
+],
+  "geometry": {"coordinates":[-1.22031089047427,51.72952088785097],"type":"Point"}
+}

--- a/data/144/483/034/7/1444830347.geojson
+++ b/data/144/483/034/7/1444830347.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"8884ff9fd03c679991f03a6075a40d05",
-    "wof:hierarchy":[],
+    "wof:geomhash":"c6cace2e420a3d9235e00625416d3821",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830347,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830347,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566336957,
     "wof:name":"Florence Park",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.223286355838576,
-    51.734588654861625,
-    -1.223286355838576,
-    51.734588654861625
+    -1.22328635583858,
+    51.73458865486162,
+    -1.22328635583858,
+    51.73458865486162
 ],
   "geometry": {"coordinates":[-1.22328635583858,51.73458865486162],"type":"Point"}
 }

--- a/data/144/483/034/7/1444830347.geojson
+++ b/data/144/483/034/7/1444830347.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830347,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.22328635584,51.7345886549,-1.22328635584,51.7345886549",
+    "geom:latitude":51.734589,
+    "geom:longitude":-1.223286,
+    "iso:country":"GB",
+    "lbl:latitude":51.734589,
+    "lbl:longitude":-1.223286,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Florence Park"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"8884ff9fd03c679991f03a6075a40d05",
+    "wof:hierarchy":[],
+    "wof:id":1444830347,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Florence Park",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.223286355838576,
+    51.734588654861625,
+    -1.223286355838576,
+    51.734588654861625
+],
+  "geometry": {"coordinates":[-1.22328635583858,51.73458865486162],"type":"Point"}
+}

--- a/data/144/483/035/7/1444830357.geojson
+++ b/data/144/483/035/7/1444830357.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"892680cb57f2c4f8f98653372fe447d7",
-    "wof:hierarchy":[],
+    "wof:geomhash":"2bf3e5c1e9f73b22b779a269e217ad55",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830357,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830357,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566336958,
     "wof:name":"Donnington",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.238507005586731,
-    51.736573080120515,
-    -1.238507005586731,
-    51.736573080120515
+    -1.23850700558673,
+    51.73657308012051,
+    -1.23850700558673,
+    51.73657308012051
 ],
   "geometry": {"coordinates":[-1.23850700558673,51.73657308012051],"type":"Point"}
 }

--- a/data/144/483/035/7/1444830357.geojson
+++ b/data/144/483/035/7/1444830357.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830357,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.23850700559,51.7365730801,-1.23850700559,51.7365730801",
+    "geom:latitude":51.736573,
+    "geom:longitude":-1.238507,
+    "iso:country":"GB",
+    "lbl:latitude":51.736573,
+    "lbl:longitude":-1.238507,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Donnington"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"892680cb57f2c4f8f98653372fe447d7",
+    "wof:hierarchy":[],
+    "wof:id":1444830357,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Donnington",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.238507005586731,
+    51.736573080120515,
+    -1.238507005586731,
+    51.736573080120515
+],
+  "geometry": {"coordinates":[-1.23850700558673,51.73657308012051],"type":"Point"}
+}

--- a/data/144/483/036/9/1444830369.geojson
+++ b/data/144/483/036/9/1444830369.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830369,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.29950404555,51.7800667876,-1.29950404555,51.7800667876",
+    "geom:latitude":51.780067,
+    "geom:longitude":-1.299504,
+    "iso:country":"GB",
+    "lbl:latitude":51.780067,
+    "lbl:longitude":-1.299504,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Godstow"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"bd05073f3957fe00046a7679b3448c11",
+    "wof:hierarchy":[],
+    "wof:id":1444830369,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Godstow",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.299504045554901,
+    51.78006678763748,
+    -1.299504045554901,
+    51.78006678763748
+],
+  "geometry": {"coordinates":[-1.2995040455549,51.78006678763748],"type":"Point"}
+}

--- a/data/144/483/036/9/1444830369.geojson
+++ b/data/144/483/036/9/1444830369.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"bd05073f3957fe00046a7679b3448c11",
-    "wof:hierarchy":[],
+    "wof:geomhash":"80d7fb0f56bd485306134b6ecc8de6e6",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830369,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830369,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566336961,
     "wof:name":"Godstow",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.299504045554901,
+    -1.2995040455549,
     51.78006678763748,
-    -1.299504045554901,
+    -1.2995040455549,
     51.78006678763748
 ],
   "geometry": {"coordinates":[-1.2995040455549,51.78006678763748],"type":"Point"}

--- a/data/144/483/037/9/1444830379.geojson
+++ b/data/144/483/037/9/1444830379.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830379,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.2451016668,51.7572891726,-1.2451016668,51.7572891726",
+    "geom:latitude":51.757289,
+    "geom:longitude":-1.245102,
+    "iso:country":"GB",
+    "lbl:latitude":51.757289,
+    "lbl:longitude":-1.245102,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Holywell"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"dd082d334492bc1f5774b6f44328af87",
+    "wof:hierarchy":[],
+    "wof:id":1444830379,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Holywell",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.245101666802802,
+    51.75728917260699,
+    -1.245101666802802,
+    51.75728917260699
+],
+  "geometry": {"coordinates":[-1.2451016668028,51.75728917260699],"type":"Point"}
+}

--- a/data/144/483/037/9/1444830379.geojson
+++ b/data/144/483/037/9/1444830379.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"dd082d334492bc1f5774b6f44328af87",
-    "wof:hierarchy":[],
+    "wof:geomhash":"ab283cf54977305088a34381a6f802bd",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830379,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830379,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566336962,
     "wof:name":"Holywell",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.245101666802802,
+    -1.2451016668028,
     51.75728917260699,
-    -1.245101666802802,
+    -1.2451016668028,
     51.75728917260699
 ],
   "geometry": {"coordinates":[-1.2451016668028,51.75728917260699],"type":"Point"}

--- a/data/144/483/039/1/1444830391.geojson
+++ b/data/144/483/039/1/1444830391.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830391,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.21172781731,51.764097989,-1.21172781731,51.764097989",
+    "geom:latitude":51.764098,
+    "geom:longitude":-1.211728,
+    "iso:country":"GB",
+    "lbl:latitude":51.764098,
+    "lbl:longitude":-1.211728,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Old Headington"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"125c42c462db7d1e1b2f7d051fe52dc2",
+    "wof:hierarchy":[],
+    "wof:id":1444830391,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Old Headington",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.211727817308023,
+    51.764097989010374,
+    -1.211727817308023,
+    51.764097989010374
+],
+  "geometry": {"coordinates":[-1.21172781730802,51.76409798901037],"type":"Point"}
+}

--- a/data/144/483/039/1/1444830391.geojson
+++ b/data/144/483/039/1/1444830391.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"125c42c462db7d1e1b2f7d051fe52dc2",
-    "wof:hierarchy":[],
+    "wof:geomhash":"ccf6e4adc6c8bc7d4bc7e7a2f417fcb0",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830391,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830391,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566336962,
     "wof:name":"Old Headington",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.211727817308023,
-    51.764097989010374,
-    -1.211727817308023,
-    51.764097989010374
+    -1.21172781730802,
+    51.76409798901037,
+    -1.21172781730802,
+    51.76409798901037
 ],
   "geometry": {"coordinates":[-1.21172781730802,51.76409798901037],"type":"Point"}
 }

--- a/data/144/483/040/3/1444830403.geojson
+++ b/data/144/483/040/3/1444830403.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444830403,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.22378703511,51.7404353723,-1.22378703511,51.7404353723",
+    "geom:latitude":51.740435,
+    "geom:longitude":-1.223787,
+    "iso:country":"GB",
+    "lbl:latitude":51.740435,
+    "lbl:longitude":-1.223787,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Cowley St John"
+    ],
+    "name:eng_x_variant":[
+        "Cowley Road Area"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"915b92d31849b6123c811030bf95d1bc",
+    "wof:hierarchy":[],
+    "wof:id":1444830403,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Cowley St John",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.223787035106608,
+    51.74043537227524,
+    -1.223787035106608,
+    51.74043537227524
+],
+  "geometry": {"coordinates":[-1.22378703510661,51.74043537227524],"type":"Point"}
+}

--- a/data/144/483/040/3/1444830403.geojson
+++ b/data/144/483/040/3/1444830403.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"915b92d31849b6123c811030bf95d1bc",
-    "wof:hierarchy":[],
+    "wof:geomhash":"f7aaf8d73f78e1e1a7313734b78e478a",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830403,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830403,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566336963,
     "wof:name":"Cowley St John",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.223787035106608,
+    -1.22378703510661,
     51.74043537227524,
-    -1.223787035106608,
+    -1.22378703510661,
     51.74043537227524
 ],
   "geometry": {"coordinates":[-1.22378703510661,51.74043537227524],"type":"Point"}

--- a/data/144/483/041/3/1444830413.geojson
+++ b/data/144/483/041/3/1444830413.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"fc7d74d98c92d0da62117b833c238914",
-    "wof:hierarchy":[],
+    "wof:geomhash":"898fde17b23b365f31ebc22fa0b89d4d",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830413,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830413,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566336966,
     "wof:name":"Temple Cowley",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.217907629987725,
-    51.737910746193194,
-    -1.217907629987725,
-    51.737910746193194
+    -1.21790762998772,
+    51.73791074619319,
+    -1.21790762998772,
+    51.73791074619319
 ],
   "geometry": {"coordinates":[-1.21790762998772,51.73791074619319],"type":"Point"}
 }

--- a/data/144/483/041/3/1444830413.geojson
+++ b/data/144/483/041/3/1444830413.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830413,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.21790762999,51.7379107462,-1.21790762999,51.7379107462",
+    "geom:latitude":51.737911,
+    "geom:longitude":-1.217908,
+    "iso:country":"GB",
+    "lbl:latitude":51.737911,
+    "lbl:longitude":-1.217908,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Temple Cowley"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"fc7d74d98c92d0da62117b833c238914",
+    "wof:hierarchy":[],
+    "wof:id":1444830413,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Temple Cowley",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.217907629987725,
+    51.737910746193194,
+    -1.217907629987725,
+    51.737910746193194
+],
+  "geometry": {"coordinates":[-1.21790762998772,51.73791074619319],"type":"Point"}
+}

--- a/data/144/483/042/5/1444830425.geojson
+++ b/data/144/483/042/5/1444830425.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444830425,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.27329706215,51.7727027222,-1.27329706215,51.7727027222",
+    "geom:latitude":51.772703,
+    "geom:longitude":-1.273297,
+    "iso:country":"GB",
+    "lbl:latitude":51.772703,
+    "lbl:longitude":-1.273297,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "The Waterways"
+    ],
+    "name:eng_x_variant":[
+        "Waterways"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"5c0dea10b3eb0a3a0268cdf6b1b6d992",
+    "wof:hierarchy":[],
+    "wof:id":1444830425,
+    "wof:lastmodified":1566334997,
+    "wof:name":"The Waterways",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.273297062153943,
+    51.77270272220495,
+    -1.273297062153943,
+    51.77270272220495
+],
+  "geometry": {"coordinates":[-1.27329706215394,51.77270272220495],"type":"Point"}
+}

--- a/data/144/483/042/5/1444830425.geojson
+++ b/data/144/483/042/5/1444830425.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"5c0dea10b3eb0a3a0268cdf6b1b6d992",
-    "wof:hierarchy":[],
+    "wof:geomhash":"ce84778d71cb5f4230ff822980f64f59",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830425,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830425,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566336967,
     "wof:name":"The Waterways",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.273297062153943,
+    -1.27329706215394,
     51.77270272220495,
-    -1.273297062153943,
+    -1.27329706215394,
     51.77270272220495
 ],
   "geometry": {"coordinates":[-1.27329706215394,51.77270272220495],"type":"Point"}

--- a/data/144/483/043/7/1444830437.geojson
+++ b/data/144/483/043/7/1444830437.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"1fc3a7731e19fb637cc12a57d311a09e",
-    "wof:hierarchy":[],
+    "wof:geomhash":"18ce54b06da0c69cc5c1ab99a9dd7b6f",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830437,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830437,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566336967,
     "wof:name":"St John Street",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.261881574842828,
+    -1.26188157484283,
     51.75621773089041,
-    -1.261881574842828,
+    -1.26188157484283,
     51.75621773089041
 ],
   "geometry": {"coordinates":[-1.26188157484283,51.75621773089041],"type":"Point"}

--- a/data/144/483/043/7/1444830437.geojson
+++ b/data/144/483/043/7/1444830437.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830437,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.26188157484,51.7562177309,-1.26188157484,51.7562177309",
+    "geom:latitude":51.756218,
+    "geom:longitude":-1.261882,
+    "iso:country":"GB",
+    "lbl:latitude":51.756218,
+    "lbl:longitude":-1.261882,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "St John Street"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"1fc3a7731e19fb637cc12a57d311a09e",
+    "wof:hierarchy":[],
+    "wof:id":1444830437,
+    "wof:lastmodified":1566334997,
+    "wof:name":"St John Street",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.261881574842828,
+    51.75621773089041,
+    -1.261881574842828,
+    51.75621773089041
+],
+  "geometry": {"coordinates":[-1.26188157484283,51.75621773089041],"type":"Point"}
+}

--- a/data/144/483/044/7/1444830447.geojson
+++ b/data/144/483/044/7/1444830447.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830447,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.2592136696,51.7510992536,-1.2592136696,51.7510992536",
+    "geom:latitude":51.751099,
+    "geom:longitude":-1.259214,
+    "iso:country":"GB",
+    "lbl:latitude":51.751099,
+    "lbl:longitude":-1.259214,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "St. Ebbes"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"a54940276bee39e8589531eba10a0674",
+    "wof:hierarchy":[],
+    "wof:id":1444830447,
+    "wof:lastmodified":1566334997,
+    "wof:name":"St. Ebbes",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.259213669600318,
+    51.751099253575894,
+    -1.259213669600318,
+    51.751099253575894
+],
+  "geometry": {"coordinates":[-1.25921366960032,51.75109925357589],"type":"Point"}
+}

--- a/data/144/483/044/7/1444830447.geojson
+++ b/data/144/483/044/7/1444830447.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"a54940276bee39e8589531eba10a0674",
-    "wof:hierarchy":[],
+    "wof:geomhash":"f72b7f8ea84d2dc6e6611f912bedd2f9",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830447,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830447,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566336968,
     "wof:name":"St. Ebbes",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.259213669600318,
-    51.751099253575894,
-    -1.259213669600318,
-    51.751099253575894
+    -1.25921366960032,
+    51.75109925357589,
+    -1.25921366960032,
+    51.75109925357589
 ],
   "geometry": {"coordinates":[-1.25921366960032,51.75109925357589],"type":"Point"}
 }

--- a/data/144/483/045/9/1444830459.geojson
+++ b/data/144/483/045/9/1444830459.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830459,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.24126074156,51.7503464874,-1.24126074156,51.7503464874",
+    "geom:latitude":51.750346,
+    "geom:longitude":-1.241261,
+    "iso:country":"GB",
+    "lbl:latitude":51.750346,
+    "lbl:longitude":-1.241261,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "St Clement's"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"f3f9ea0f6d396ff01b04a5606f99be25",
+    "wof:hierarchy":[],
+    "wof:id":1444830459,
+    "wof:lastmodified":1566334997,
+    "wof:name":"St Clement's",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.241260741560906,
+    51.75034648739602,
+    -1.241260741560906,
+    51.75034648739602
+],
+  "geometry": {"coordinates":[-1.24126074156091,51.75034648739602],"type":"Point"}
+}

--- a/data/144/483/045/9/1444830459.geojson
+++ b/data/144/483/045/9/1444830459.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"f3f9ea0f6d396ff01b04a5606f99be25",
-    "wof:hierarchy":[],
+    "wof:geomhash":"1ccbcfd9ea364b64dd8afca13a67dfed",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830459,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830459,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566336970,
     "wof:name":"St Clement's",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.241260741560906,
+    -1.24126074156091,
     51.75034648739602,
-    -1.241260741560906,
+    -1.24126074156091,
     51.75034648739602
 ],
   "geometry": {"coordinates":[-1.24126074156091,51.75034648739602],"type":"Point"}

--- a/data/144/483/046/9/1444830469.geojson
+++ b/data/144/483/046/9/1444830469.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"d81594bdb10585c3a6a8de5a3df684b2",
-    "wof:hierarchy":[],
+    "wof:geomhash":"f4b2091b6797ac807ee8643dd05fc608",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830469,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830469,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566336971,
     "wof:name":"Northway",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.220918858156887,
+    -1.22091885815689,
     51.76941859887533,
-    -1.220918858156887,
+    -1.22091885815689,
     51.76941859887533
 ],
   "geometry": {"coordinates":[-1.22091885815689,51.76941859887533],"type":"Point"}

--- a/data/144/483/046/9/1444830469.geojson
+++ b/data/144/483/046/9/1444830469.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830469,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.22091885816,51.7694185989,-1.22091885816,51.7694185989",
+    "geom:latitude":51.769419,
+    "geom:longitude":-1.220919,
+    "iso:country":"GB",
+    "lbl:latitude":51.769419,
+    "lbl:longitude":-1.220919,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Northway"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"d81594bdb10585c3a6a8de5a3df684b2",
+    "wof:hierarchy":[],
+    "wof:id":1444830469,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Northway",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.220918858156887,
+    51.76941859887533,
+    -1.220918858156887,
+    51.76941859887533
+],
+  "geometry": {"coordinates":[-1.22091885815689,51.76941859887533],"type":"Point"}
+}

--- a/data/144/483/048/1/1444830481.geojson
+++ b/data/144/483/048/1/1444830481.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444830481,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-1.20805855353,51.7450059154,-1.20805855353,51.7450059154",
+    "geom:latitude":51.745006,
+    "geom:longitude":-1.208059,
+    "iso:country":"GB",
+    "lbl:latitude":51.745006,
+    "lbl:longitude":-1.208058,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Lye Valley"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"c804a10f9d5883ab98d9594bcb060ce7",
+    "wof:hierarchy":[],
+    "wof:id":1444830481,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Lye Valley",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -1.208058553529452,
+    51.74500591535659,
+    -1.208058553529452,
+    51.74500591535659
+],
+  "geometry": {"coordinates":[-1.20805855352945,51.74500591535659],"type":"Point"}
+}

--- a/data/144/483/048/1/1444830481.geojson
+++ b/data/144/483/048/1/1444830481.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698585,
+        102191581,
+        85633159,
+        404227469,
+        101750439,
+        1360698839
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"c804a10f9d5883ab98d9594bcb060ce7",
-    "wof:hierarchy":[],
+    "wof:geomhash":"40dcd104b52fff9d3b1a273fb6031465",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698839,
+            "locality_id":101750439,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444830481,
+            "region_id":1360698585
+        }
+    ],
     "wof:id":1444830481,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566336974,
     "wof:name":"Lye Valley",
-    "wof:parent_id":-1,
+    "wof:parent_id":101750439,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -1.208058553529452,
+    -1.20805855352945,
     51.74500591535659,
-    -1.208058553529452,
+    -1.20805855352945,
     51.74500591535659
 ],
   "geometry": {"coordinates":[-1.20805855352945,51.74500591535659],"type":"Point"}

--- a/data/144/483/111/3/1444831113.geojson
+++ b/data/144/483/111/3/1444831113.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831113,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.60677403394,51.4928998969,-2.60677403394,51.4928998969",
+    "geom:latitude":51.4929,
+    "geom:longitude":-2.606774,
+    "iso:country":"GB",
+    "lbl:latitude":51.4929,
+    "lbl:longitude":-2.606774,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Eastfield"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"62c0ee5b47fd4f06494924dc278fc6fc",
+    "wof:hierarchy":[],
+    "wof:id":1444831113,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Eastfield",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.606774033937143,
+    51.49289989689983,
+    -2.606774033937143,
+    51.49289989689983
+],
+  "geometry": {"coordinates":[-2.60677403393714,51.49289989689983],"type":"Point"}
+}

--- a/data/144/483/111/3/1444831113.geojson
+++ b/data/144/483/111/3/1444831113.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"62c0ee5b47fd4f06494924dc278fc6fc",
-    "wof:hierarchy":[],
+    "wof:geomhash":"efcc8bffb60b827bd9b7f4e3cee6c877",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831113,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831113,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340861,
     "wof:name":"Eastfield",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.606774033937143,
+    -2.60677403393714,
     51.49289989689983,
-    -2.606774033937143,
+    -2.60677403393714,
     51.49289989689983
 ],
   "geometry": {"coordinates":[-2.60677403393714,51.49289989689983],"type":"Point"}

--- a/data/144/483/111/7/1444831117.geojson
+++ b/data/144/483/111/7/1444831117.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831117,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.51770347724,51.4665166789,-2.51770347724,51.4665166789",
+    "geom:latitude":51.466517,
+    "geom:longitude":-2.517703,
+    "iso:country":"GB",
+    "lbl:latitude":51.466517,
+    "lbl:longitude":-2.517703,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Kingsfield"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"b4546c1cb72444ec8598eb0703b0fecb",
+    "wof:hierarchy":[],
+    "wof:id":1444831117,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Kingsfield",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.517703477243407,
+    51.46651667889958,
+    -2.517703477243407,
+    51.46651667889958
+],
+  "geometry": {"coordinates":[-2.51770347724341,51.46651667889958],"type":"Point"}
+}

--- a/data/144/483/111/7/1444831117.geojson
+++ b/data/144/483/111/7/1444831117.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"b4546c1cb72444ec8598eb0703b0fecb",
-    "wof:hierarchy":[],
+    "wof:geomhash":"e304c8474ec214d42caec922305b9270",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831117,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831117,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340864,
     "wof:name":"Kingsfield",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.517703477243407,
+    -2.51770347724341,
     51.46651667889958,
-    -2.517703477243407,
+    -2.51770347724341,
     51.46651667889958
 ],
   "geometry": {"coordinates":[-2.51770347724341,51.46651667889958],"type":"Point"}

--- a/data/144/483/113/9/1444831139.geojson
+++ b/data/144/483/113/9/1444831139.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831139,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.52033328829,51.4639523138,-2.52033328829,51.4639523138",
+    "geom:latitude":51.463952,
+    "geom:longitude":-2.520333,
+    "iso:country":"GB",
+    "lbl:latitude":51.463952,
+    "lbl:longitude":-2.520333,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Two Mile Hill"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"467c6209fcaa3327300df3d9de152348",
+    "wof:hierarchy":[],
+    "wof:id":1444831139,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Two Mile Hill",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.520333288288281,
+    51.463952313797876,
+    -2.520333288288281,
+    51.463952313797876
+],
+  "geometry": {"coordinates":[-2.52033328828828,51.46395231379788],"type":"Point"}
+}

--- a/data/144/483/113/9/1444831139.geojson
+++ b/data/144/483/113/9/1444831139.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"467c6209fcaa3327300df3d9de152348",
-    "wof:hierarchy":[],
+    "wof:geomhash":"dc6b3afff97007e259d674c92ffb17e3",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831139,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831139,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340865,
     "wof:name":"Two Mile Hill",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.520333288288281,
-    51.463952313797876,
-    -2.520333288288281,
-    51.463952313797876
+    -2.52033328828828,
+    51.46395231379788,
+    -2.52033328828828,
+    51.46395231379788
 ],
   "geometry": {"coordinates":[-2.52033328828828,51.46395231379788],"type":"Point"}
 }

--- a/data/144/483/114/7/1444831147.geojson
+++ b/data/144/483/114/7/1444831147.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"bdd512283c8f2c81aac46038a8fdcc08",
-    "wof:hierarchy":[],
+    "wof:geomhash":"94a59088fcee985a6401ba60158d6172",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831147,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831147,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340865,
     "wof:name":"Hillfields",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.523191778554447,
+    -2.52319177855445,
     51.47534838900102,
-    -2.523191778554447,
+    -2.52319177855445,
     51.47534838900102
 ],
   "geometry": {"coordinates":[-2.52319177855445,51.47534838900102],"type":"Point"}

--- a/data/144/483/114/7/1444831147.geojson
+++ b/data/144/483/114/7/1444831147.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831147,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.52319177855,51.475348389,-2.52319177855,51.475348389",
+    "geom:latitude":51.475348,
+    "geom:longitude":-2.523192,
+    "iso:country":"GB",
+    "lbl:latitude":51.475348,
+    "lbl:longitude":-2.523192,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Hillfields"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"bdd512283c8f2c81aac46038a8fdcc08",
+    "wof:hierarchy":[],
+    "wof:id":1444831147,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Hillfields",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.523191778554447,
+    51.47534838900102,
+    -2.523191778554447,
+    51.47534838900102
+],
+  "geometry": {"coordinates":[-2.52319177855445,51.47534838900102],"type":"Point"}
+}

--- a/data/144/483/115/9/1444831159.geojson
+++ b/data/144/483/115/9/1444831159.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"229168ea8bead3a70543548dec161c32",
-    "wof:hierarchy":[],
+    "wof:geomhash":"20790b73ef49935ffee0310458700aaf",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831159,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831159,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340868,
     "wof:name":"Mayfield Park",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.528908759086779,
+    -2.52890875908678,
     51.4724284159793,
-    -2.528908759086779,
+    -2.52890875908678,
     51.4724284159793
 ],
   "geometry": {"coordinates":[-2.52890875908678,51.4724284159793],"type":"Point"}

--- a/data/144/483/115/9/1444831159.geojson
+++ b/data/144/483/115/9/1444831159.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831159,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.52890875909,51.472428416,-2.52890875909,51.472428416",
+    "geom:latitude":51.472428,
+    "geom:longitude":-2.528909,
+    "iso:country":"GB",
+    "lbl:latitude":51.472428,
+    "lbl:longitude":-2.528909,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Mayfield Park"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"229168ea8bead3a70543548dec161c32",
+    "wof:hierarchy":[],
+    "wof:id":1444831159,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Mayfield Park",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.528908759086779,
+    51.4724284159793,
+    -2.528908759086779,
+    51.4724284159793
+],
+  "geometry": {"coordinates":[-2.52890875908678,51.4724284159793],"type":"Point"}
+}

--- a/data/144/483/116/7/1444831167.geojson
+++ b/data/144/483/116/7/1444831167.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831167,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.53828460716,51.4728557408,-2.53828460716,51.4728557408",
+    "geom:latitude":51.472856,
+    "geom:longitude":-2.538285,
+    "iso:country":"GB",
+    "lbl:latitude":51.472856,
+    "lbl:longitude":-2.538285,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Ridgeway"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"ad24fb52131513c7e840526393696479",
+    "wof:hierarchy":[],
+    "wof:id":1444831167,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Ridgeway",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.538284607159803,
+    51.47285574077915,
+    -2.538284607159803,
+    51.47285574077915
+],
+  "geometry": {"coordinates":[-2.5382846071598,51.47285574077915],"type":"Point"}
+}

--- a/data/144/483/116/7/1444831167.geojson
+++ b/data/144/483/116/7/1444831167.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"ad24fb52131513c7e840526393696479",
-    "wof:hierarchy":[],
+    "wof:geomhash":"39b84794d33f091e282b43fae473b83c",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831167,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831167,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340869,
     "wof:name":"Ridgeway",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.538284607159803,
+    -2.5382846071598,
     51.47285574077915,
-    -2.538284607159803,
+    -2.5382846071598,
     51.47285574077915
 ],
   "geometry": {"coordinates":[-2.5382846071598,51.47285574077915],"type":"Point"}

--- a/data/144/483/117/5/1444831175.geojson
+++ b/data/144/483/117/5/1444831175.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831175,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.54565951205,51.4743869551,-2.54565951205,51.4743869551",
+    "geom:latitude":51.474387,
+    "geom:longitude":-2.54566,
+    "iso:country":"GB",
+    "lbl:latitude":51.474387,
+    "lbl:longitude":-2.54566,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Upper Eastville"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"7c4fb51c46c23afcd35770d7487b93a2",
+    "wof:hierarchy":[],
+    "wof:id":1444831175,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Upper Eastville",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.545659512046512,
+    51.47438695510863,
+    -2.545659512046512,
+    51.47438695510863
+],
+  "geometry": {"coordinates":[-2.54565951204651,51.47438695510863],"type":"Point"}
+}

--- a/data/144/483/117/5/1444831175.geojson
+++ b/data/144/483/117/5/1444831175.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"7c4fb51c46c23afcd35770d7487b93a2",
-    "wof:hierarchy":[],
+    "wof:geomhash":"8ccc03d207474e35184bd7d3db3cbee3",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831175,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831175,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340872,
     "wof:name":"Upper Eastville",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.545659512046512,
+    -2.54565951204651,
     51.47438695510863,
-    -2.545659512046512,
+    -2.54565951204651,
     51.47438695510863
 ],
   "geometry": {"coordinates":[-2.54565951204651,51.47438695510863],"type":"Point"}

--- a/data/144/483/119/5/1444831195.geojson
+++ b/data/144/483/119/5/1444831195.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"aaf9330351ca47711e6d5f48923e99a7",
-    "wof:hierarchy":[],
+    "wof:geomhash":"5e931903f75f92d742db9e30378f027b",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831195,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831195,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340873,
     "wof:name":"Chester Park",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.521248005173454,
+    -2.52124800517345,
     51.4705054048452,
-    -2.521248005173454,
+    -2.52124800517345,
     51.4705054048452
 ],
   "geometry": {"coordinates":[-2.52124800517345,51.4705054048452],"type":"Point"}

--- a/data/144/483/119/5/1444831195.geojson
+++ b/data/144/483/119/5/1444831195.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831195,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.52124800517,51.4705054048,-2.52124800517,51.4705054048",
+    "geom:latitude":51.470505,
+    "geom:longitude":-2.521248,
+    "iso:country":"GB",
+    "lbl:latitude":51.470505,
+    "lbl:longitude":-2.521248,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Chester Park"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"aaf9330351ca47711e6d5f48923e99a7",
+    "wof:hierarchy":[],
+    "wof:id":1444831195,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Chester Park",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.521248005173454,
+    51.4705054048452,
+    -2.521248005173454,
+    51.4705054048452
+],
+  "geometry": {"coordinates":[-2.52124800517345,51.4705054048452],"type":"Point"}
+}

--- a/data/144/483/120/3/1444831203.geojson
+++ b/data/144/483/120/3/1444831203.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831203,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.54571668185,51.4717161991,-2.54571668185,51.4717161991",
+    "geom:latitude":51.471716,
+    "geom:longitude":-2.545717,
+    "iso:country":"GB",
+    "lbl:latitude":51.471716,
+    "lbl:longitude":-2.545717,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Clay Bottom"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"4946606be8e984b407c3b93d085e63fa",
+    "wof:hierarchy":[],
+    "wof:id":1444831203,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Clay Bottom",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.545716681851835,
+    51.47171619908446,
+    -2.545716681851835,
+    51.47171619908446
+],
+  "geometry": {"coordinates":[-2.54571668185184,51.47171619908446],"type":"Point"}
+}

--- a/data/144/483/120/3/1444831203.geojson
+++ b/data/144/483/120/3/1444831203.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"4946606be8e984b407c3b93d085e63fa",
-    "wof:hierarchy":[],
+    "wof:geomhash":"bf9786745eb8e08e41a4ade316787799",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831203,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831203,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340876,
     "wof:name":"Clay Bottom",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.545716681851835,
+    -2.54571668185184,
     51.47171619908446,
-    -2.545716681851835,
+    -2.54571668185184,
     51.47171619908446
 ],
   "geometry": {"coordinates":[-2.54571668185184,51.47171619908446],"type":"Point"}

--- a/data/144/483/121/5/1444831215.geojson
+++ b/data/144/483/121/5/1444831215.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"ae4a501601448e215798a9ede5d6a01c",
-    "wof:hierarchy":[],
+    "wof:geomhash":"83f426f1ac89310c83bd628001e95d97",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831215,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831215,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340877,
     "wof:name":"Rose Green",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.548403662702031,
-    51.466623524318145,
-    -2.548403662702031,
-    51.466623524318145
+    -2.54840366270203,
+    51.46662352431814,
+    -2.54840366270203,
+    51.46662352431814
 ],
   "geometry": {"coordinates":[-2.54840366270203,51.46662352431814],"type":"Point"}
 }

--- a/data/144/483/121/5/1444831215.geojson
+++ b/data/144/483/121/5/1444831215.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831215,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.5484036627,51.4666235243,-2.5484036627,51.4666235243",
+    "geom:latitude":51.466624,
+    "geom:longitude":-2.548404,
+    "iso:country":"GB",
+    "lbl:latitude":51.466623,
+    "lbl:longitude":-2.548404,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Rose Green"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"ae4a501601448e215798a9ede5d6a01c",
+    "wof:hierarchy":[],
+    "wof:id":1444831215,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Rose Green",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.548403662702031,
+    51.466623524318145,
+    -2.548403662702031,
+    51.466623524318145
+],
+  "geometry": {"coordinates":[-2.54840366270203,51.46662352431814],"type":"Point"}
+}

--- a/data/144/483/122/5/1444831225.geojson
+++ b/data/144/483/122/5/1444831225.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"f2fdc30ed5bba65cea933a632c8cc0e9",
-    "wof:hierarchy":[],
+    "wof:geomhash":"7851a29b76d16d867ab82d37ea85229e",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831225,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831225,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340878,
     "wof:name":"Crofts End",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.542629512364375,
-    51.465946832441944,
-    -2.542629512364375,
-    51.465946832441944
+    -2.54262951236438,
+    51.46594683244194,
+    -2.54262951236438,
+    51.46594683244194
 ],
   "geometry": {"coordinates":[-2.54262951236438,51.46594683244194],"type":"Point"}
 }

--- a/data/144/483/122/5/1444831225.geojson
+++ b/data/144/483/122/5/1444831225.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831225,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.54262951236,51.4659468324,-2.54262951236,51.4659468324",
+    "geom:latitude":51.465947,
+    "geom:longitude":-2.54263,
+    "iso:country":"GB",
+    "lbl:latitude":51.465947,
+    "lbl:longitude":-2.542629,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Crofts End"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"f2fdc30ed5bba65cea933a632c8cc0e9",
+    "wof:hierarchy":[],
+    "wof:id":1444831225,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Crofts End",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.542629512364375,
+    51.465946832441944,
+    -2.542629512364375,
+    51.465946832441944
+],
+  "geometry": {"coordinates":[-2.54262951236438,51.46594683244194],"type":"Point"}
+}

--- a/data/144/483/123/5/1444831235.geojson
+++ b/data/144/483/123/5/1444831235.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831235,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.56669800041,51.4606754153,-2.56669800041,51.4606754153",
+    "geom:latitude":51.460675,
+    "geom:longitude":-2.566698,
+    "iso:country":"GB",
+    "lbl:latitude":51.460675,
+    "lbl:longitude":-2.566698,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Upper Easton"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"2f6868ff93b2e1ea5372326eb71e404a",
+    "wof:hierarchy":[],
+    "wof:id":1444831235,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Upper Easton",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.566698000405494,
+    51.46067541531233,
+    -2.566698000405494,
+    51.46067541531233
+],
+  "geometry": {"coordinates":[-2.56669800040549,51.46067541531233],"type":"Point"}
+}

--- a/data/144/483/123/5/1444831235.geojson
+++ b/data/144/483/123/5/1444831235.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"2f6868ff93b2e1ea5372326eb71e404a",
-    "wof:hierarchy":[],
+    "wof:geomhash":"1fb0500ef071b8de80e00bcd16745749",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831235,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831235,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340878,
     "wof:name":"Upper Easton",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.566698000405494,
+    -2.56669800040549,
     51.46067541531233,
-    -2.566698000405494,
+    -2.56669800040549,
     51.46067541531233
 ],
   "geometry": {"coordinates":[-2.56669800040549,51.46067541531233],"type":"Point"}

--- a/data/144/483/124/9/1444831249.geojson
+++ b/data/144/483/124/9/1444831249.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"e2cc645669493854c82c9d6315637c76",
-    "wof:hierarchy":[],
+    "wof:geomhash":"c6dc42b1ae38dea40859c5eb9fc01aa4",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831249,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831249,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340881,
     "wof:name":"Baptist Mills",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.575559320230608,
+    -2.57555932023061,
     51.46697967390642,
-    -2.575559320230608,
+    -2.57555932023061,
     51.46697967390642
 ],
   "geometry": {"coordinates":[-2.57555932023061,51.46697967390642],"type":"Point"}

--- a/data/144/483/124/9/1444831249.geojson
+++ b/data/144/483/124/9/1444831249.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831249,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.57555932023,51.4669796739,-2.57555932023,51.4669796739",
+    "geom:latitude":51.46698,
+    "geom:longitude":-2.575559,
+    "iso:country":"GB",
+    "lbl:latitude":51.46698,
+    "lbl:longitude":-2.575559,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Baptist Mills"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"e2cc645669493854c82c9d6315637c76",
+    "wof:hierarchy":[],
+    "wof:id":1444831249,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Baptist Mills",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.575559320230608,
+    51.46697967390642,
+    -2.575559320230608,
+    51.46697967390642
+],
+  "geometry": {"coordinates":[-2.57555932023061,51.46697967390642],"type":"Point"}
+}

--- a/data/144/483/125/7/1444831257.geojson
+++ b/data/144/483/125/7/1444831257.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"2bd2f3527763a8dfaa279dce0a1e19f1",
-    "wof:hierarchy":[],
+    "wof:geomhash":"c16533fed0e63a6a6238b592db8638b8",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831257,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831257,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340882,
     "wof:name":"Montpelier",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.587450639737859,
+    -2.58745063973786,
     51.46776319321557,
-    -2.587450639737859,
+    -2.58745063973786,
     51.46776319321557
 ],
   "geometry": {"coordinates":[-2.58745063973786,51.46776319321557],"type":"Point"}

--- a/data/144/483/125/7/1444831257.geojson
+++ b/data/144/483/125/7/1444831257.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831257,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.58745063974,51.4677631932,-2.58745063974,51.4677631932",
+    "geom:latitude":51.467763,
+    "geom:longitude":-2.587451,
+    "iso:country":"GB",
+    "lbl:latitude":51.467763,
+    "lbl:longitude":-2.587451,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Montpelier"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"2bd2f3527763a8dfaa279dce0a1e19f1",
+    "wof:hierarchy":[],
+    "wof:id":1444831257,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Montpelier",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.587450639737859,
+    51.46776319321557,
+    -2.587450639737859,
+    51.46776319321557
+],
+  "geometry": {"coordinates":[-2.58745063973786,51.46776319321557],"type":"Point"}
+}

--- a/data/144/483/126/9/1444831269.geojson
+++ b/data/144/483/126/9/1444831269.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831269,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.61331997665,51.4775916559,-2.61331997665,51.4775916559",
+    "geom:latitude":51.477592,
+    "geom:longitude":-2.61332,
+    "iso:country":"GB",
+    "lbl:latitude":51.477592,
+    "lbl:longitude":-2.61332,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Westbury Park"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"2232f5bcdd43e12ca03e3393314ac37a",
+    "wof:hierarchy":[],
+    "wof:id":1444831269,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Westbury Park",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.613319976646661,
+    51.47759165594701,
+    -2.613319976646661,
+    51.47759165594701
+],
+  "geometry": {"coordinates":[-2.61331997664666,51.47759165594701],"type":"Point"}
+}

--- a/data/144/483/126/9/1444831269.geojson
+++ b/data/144/483/126/9/1444831269.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"2232f5bcdd43e12ca03e3393314ac37a",
-    "wof:hierarchy":[],
+    "wof:geomhash":"cd19933867b1b3b255d928630cba14e9",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831269,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831269,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340883,
     "wof:name":"Westbury Park",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.613319976646661,
+    -2.61331997664666,
     51.47759165594701,
-    -2.613319976646661,
+    -2.61331997664666,
     51.47759165594701
 ],
   "geometry": {"coordinates":[-2.61331997664666,51.47759165594701],"type":"Point"}

--- a/data/144/483/127/5/1444831275.geojson
+++ b/data/144/483/127/5/1444831275.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831275,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.63367242734,51.4769507338,-2.63367242734,51.4769507338",
+    "geom:latitude":51.476951,
+    "geom:longitude":-2.633672,
+    "iso:country":"GB",
+    "lbl:latitude":51.476951,
+    "lbl:longitude":-2.633672,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Sneyd Park"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"262e75a65ed600d7ea3d7133e3a05ea5",
+    "wof:hierarchy":[],
+    "wof:id":1444831275,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Sneyd Park",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.633672427341763,
+    51.476950733791355,
+    -2.633672427341763,
+    51.476950733791355
+],
+  "geometry": {"coordinates":[-2.63367242734176,51.47695073379136],"type":"Point"}
+}

--- a/data/144/483/127/5/1444831275.geojson
+++ b/data/144/483/127/5/1444831275.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"262e75a65ed600d7ea3d7133e3a05ea5",
-    "wof:hierarchy":[],
+    "wof:geomhash":"4bc1b1a6241e0838c606b19e6e9c4f83",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831275,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831275,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340886,
     "wof:name":"Sneyd Park",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.633672427341763,
-    51.476950733791355,
-    -2.633672427341763,
-    51.476950733791355
+    -2.63367242734176,
+    51.47695073379136,
+    -2.63367242734176,
+    51.47695073379136
 ],
   "geometry": {"coordinates":[-2.63367242734176,51.47695073379136],"type":"Point"}
 }

--- a/data/144/483/128/7/1444831287.geojson
+++ b/data/144/483/128/7/1444831287.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"976bb279e9ae0edaa93b81a55171858e",
-    "wof:hierarchy":[],
+    "wof:geomhash":"b529694fc3b141cc2bd94933fb96909b",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831287,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831287,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340887,
     "wof:name":"Canon's Marsh",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.601371487334087,
+    -2.60137148733409,
     51.44906190273711,
-    -2.601371487334087,
+    -2.60137148733409,
     51.44906190273711
 ],
   "geometry": {"coordinates":[-2.60137148733409,51.44906190273711],"type":"Point"}

--- a/data/144/483/128/7/1444831287.geojson
+++ b/data/144/483/128/7/1444831287.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831287,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.60137148733,51.4490619027,-2.60137148733,51.4490619027",
+    "geom:latitude":51.449062,
+    "geom:longitude":-2.601371,
+    "iso:country":"GB",
+    "lbl:latitude":51.449062,
+    "lbl:longitude":-2.601371,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Canon's Marsh"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"976bb279e9ae0edaa93b81a55171858e",
+    "wof:hierarchy":[],
+    "wof:id":1444831287,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Canon's Marsh",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.601371487334087,
+    51.44906190273711,
+    -2.601371487334087,
+    51.44906190273711
+],
+  "geometry": {"coordinates":[-2.60137148733409,51.44906190273711],"type":"Point"}
+}

--- a/data/144/483/129/5/1444831295.geojson
+++ b/data/144/483/129/5/1444831295.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831295,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.61196219377,51.4583556208,-2.61196219377,51.4583556208",
+    "geom:latitude":51.458356,
+    "geom:longitude":-2.611962,
+    "iso:country":"GB",
+    "lbl:latitude":51.458356,
+    "lbl:longitude":-2.611962,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Victoria Park"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"1b08e717f64eb673bbf63ce352924184",
+    "wof:hierarchy":[],
+    "wof:id":1444831295,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Victoria Park",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.611962193770232,
+    51.45835562080096,
+    -2.611962193770232,
+    51.45835562080096
+],
+  "geometry": {"coordinates":[-2.61196219377023,51.45835562080096],"type":"Point"}
+}

--- a/data/144/483/129/5/1444831295.geojson
+++ b/data/144/483/129/5/1444831295.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"1b08e717f64eb673bbf63ce352924184",
-    "wof:hierarchy":[],
+    "wof:geomhash":"9843acdbb13ff03aa34eb4e59c223b53",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831295,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831295,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340887,
     "wof:name":"Victoria Park",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.611962193770232,
+    -2.61196219377023,
     51.45835562080096,
-    -2.611962193770232,
+    -2.61196219377023,
     51.45835562080096
 ],
   "geometry": {"coordinates":[-2.61196219377023,51.45835562080096],"type":"Point"}

--- a/data/144/483/130/5/1444831305.geojson
+++ b/data/144/483/130/5/1444831305.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"fc1e0773f1aec4e92aa8840d36098634",
-    "wof:hierarchy":[],
+    "wof:geomhash":"13b268db97dbc057244c270122920ca0",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831305,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831305,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340888,
     "wof:name":"Tyndall's Park",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -43,9 +60,9 @@
 },
   "bbox": [
     -2.60487313791014,
-    51.458640592317415,
+    51.45864059231742,
     -2.60487313791014,
-    51.458640592317415
+    51.45864059231742
 ],
   "geometry": {"coordinates":[-2.60487313791014,51.45864059231742],"type":"Point"}
 }

--- a/data/144/483/130/5/1444831305.geojson
+++ b/data/144/483/130/5/1444831305.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831305,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.60487313791,51.4586405923,-2.60487313791,51.4586405923",
+    "geom:latitude":51.458641,
+    "geom:longitude":-2.604873,
+    "iso:country":"GB",
+    "lbl:latitude":51.458641,
+    "lbl:longitude":-2.604873,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Tyndall's Park"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"fc1e0773f1aec4e92aa8840d36098634",
+    "wof:hierarchy":[],
+    "wof:id":1444831305,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Tyndall's Park",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.60487313791014,
+    51.458640592317415,
+    -2.60487313791014,
+    51.458640592317415
+],
+  "geometry": {"coordinates":[-2.60487313791014,51.45864059231742],"type":"Point"}
+}

--- a/data/144/483/131/3/1444831313.geojson
+++ b/data/144/483/131/3/1444831313.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444831313,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.59767688867,51.4524108874,-2.59767688867,51.4524108874",
+    "geom:latitude":51.452411,
+    "geom:longitude":-2.597677,
+    "iso:country":"GB",
+    "lbl:latitude":51.452411,
+    "lbl:longitude":-2.597677,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "The Centre"
+    ],
+    "name:eng_x_variant":[
+        "Tramway Centre"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"017cd468bfb4e872fd5d23f22d22ed92",
+    "wof:hierarchy":[],
+    "wof:id":1444831313,
+    "wof:lastmodified":1566334999,
+    "wof:name":"The Centre",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.597676888665068,
+    51.45241088743049,
+    -2.597676888665068,
+    51.45241088743049
+],
+  "geometry": {"coordinates":[-2.59767688866507,51.45241088743049],"type":"Point"}
+}

--- a/data/144/483/131/3/1444831313.geojson
+++ b/data/144/483/131/3/1444831313.geojson
@@ -29,15 +29,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"017cd468bfb4e872fd5d23f22d22ed92",
-    "wof:hierarchy":[],
+    "wof:geomhash":"554d95876e96704016e949cc04f2fb08",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831313,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831313,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340891,
     "wof:name":"The Centre",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,9 +62,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.597676888665068,
+    -2.59767688866507,
     51.45241088743049,
-    -2.597676888665068,
+    -2.59767688866507,
     51.45241088743049
 ],
   "geometry": {"coordinates":[-2.59767688866507,51.45241088743049],"type":"Point"}

--- a/data/144/483/132/3/1444831323.geojson
+++ b/data/144/483/132/3/1444831323.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"b43ae58b63310809873948f04bfa0e57",
-    "wof:hierarchy":[],
+    "wof:geomhash":"63fda05f466d697511dd798e8a345f6d",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831323,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831323,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340892,
     "wof:name":"City Centre",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.594118068283692,
+    -2.59411806828369,
     51.45472653105302,
-    -2.594118068283692,
+    -2.59411806828369,
     51.45472653105302
 ],
   "geometry": {"coordinates":[-2.59411806828369,51.45472653105302],"type":"Point"}

--- a/data/144/483/132/3/1444831323.geojson
+++ b/data/144/483/132/3/1444831323.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831323,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.59411806828,51.4547265311,-2.59411806828,51.4547265311",
+    "geom:latitude":51.454727,
+    "geom:longitude":-2.594118,
+    "iso:country":"GB",
+    "lbl:latitude":51.454726,
+    "lbl:longitude":-2.594118,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":16.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "City Centre"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"b43ae58b63310809873948f04bfa0e57",
+    "wof:hierarchy":[],
+    "wof:id":1444831323,
+    "wof:lastmodified":1566334999,
+    "wof:name":"City Centre",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.594118068283692,
+    51.45472653105302,
+    -2.594118068283692,
+    51.45472653105302
+],
+  "geometry": {"coordinates":[-2.59411806828369,51.45472653105302],"type":"Point"}
+}

--- a/data/144/483/133/1/1444831331.geojson
+++ b/data/144/483/133/1/1444831331.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"94c71dd3baf3124929d281231df3598c",
-    "wof:hierarchy":[],
+    "wof:geomhash":"ac496efacdc2bb8d6bf2e5bfa6845c5c",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831331,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831331,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340893,
     "wof:name":"The Dings",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.573937127004557,
+    -2.57393712700456,
     51.45116395375022,
-    -2.573937127004557,
+    -2.57393712700456,
     51.45116395375022
 ],
   "geometry": {"coordinates":[-2.57393712700456,51.45116395375022],"type":"Point"}

--- a/data/144/483/133/1/1444831331.geojson
+++ b/data/144/483/133/1/1444831331.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831331,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.573937127,51.4511639538,-2.573937127,51.4511639538",
+    "geom:latitude":51.451164,
+    "geom:longitude":-2.573937,
+    "iso:country":"GB",
+    "lbl:latitude":51.451164,
+    "lbl:longitude":-2.573937,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "The Dings"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"94c71dd3baf3124929d281231df3598c",
+    "wof:hierarchy":[],
+    "wof:id":1444831331,
+    "wof:lastmodified":1566334999,
+    "wof:name":"The Dings",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.573937127004557,
+    51.45116395375022,
+    -2.573937127004557,
+    51.45116395375022
+],
+  "geometry": {"coordinates":[-2.57393712700456,51.45116395375022],"type":"Point"}
+}

--- a/data/144/483/134/3/1444831343.geojson
+++ b/data/144/483/134/3/1444831343.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"dcfc3a7440de17ab1ff0e9781f0c25ac",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d21324a868fcd0fdf2f800adcdd65365",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831343,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831343,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340893,
     "wof:name":"Russell Town",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.562731845161187,
+    -2.56273184516119,
     51.45586649707353,
-    -2.562731845161187,
+    -2.56273184516119,
     51.45586649707353
 ],
   "geometry": {"coordinates":[-2.56273184516119,51.45586649707353],"type":"Point"}

--- a/data/144/483/134/3/1444831343.geojson
+++ b/data/144/483/134/3/1444831343.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831343,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.56273184516,51.4558664971,-2.56273184516,51.4558664971",
+    "geom:latitude":51.455866,
+    "geom:longitude":-2.562732,
+    "iso:country":"GB",
+    "lbl:latitude":51.455866,
+    "lbl:longitude":-2.562732,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Russell Town"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"dcfc3a7440de17ab1ff0e9781f0c25ac",
+    "wof:hierarchy":[],
+    "wof:id":1444831343,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Russell Town",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.562731845161187,
+    51.45586649707353,
+    -2.562731845161187,
+    51.45586649707353
+],
+  "geometry": {"coordinates":[-2.56273184516119,51.45586649707353],"type":"Point"}
+}

--- a/data/144/483/135/5/1444831355.geojson
+++ b/data/144/483/135/5/1444831355.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831355,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.55204109157,51.4547265311,-2.55204109157,51.4547265311",
+    "geom:latitude":51.454727,
+    "geom:longitude":-2.552041,
+    "iso:country":"GB",
+    "lbl:latitude":51.454726,
+    "lbl:longitude":-2.552041,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Netham"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"ada348ae83594b63a83e4ef8c1af76a2",
+    "wof:hierarchy":[],
+    "wof:id":1444831355,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Netham",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.552041091565726,
+    51.45472653105301,
+    -2.552041091565726,
+    51.45472653105301
+],
+  "geometry": {"coordinates":[-2.55204109156573,51.45472653105301],"type":"Point"}
+}

--- a/data/144/483/135/5/1444831355.geojson
+++ b/data/144/483/135/5/1444831355.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"ada348ae83594b63a83e4ef8c1af76a2",
-    "wof:hierarchy":[],
+    "wof:geomhash":"17177cb64b68c9a762514a50df057e4e",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831355,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831355,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340897,
     "wof:name":"Netham",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.552041091565726,
+    -2.55204109156573,
     51.45472653105301,
-    -2.552041091565726,
+    -2.55204109156573,
     51.45472653105301
 ],
   "geometry": {"coordinates":[-2.55204109156573,51.45472653105301],"type":"Point"}

--- a/data/144/483/136/5/1444831365.geojson
+++ b/data/144/483/136/5/1444831365.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831365,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.53770576288,51.4552787056,-2.53770576288,51.4552787056",
+    "geom:latitude":51.455279,
+    "geom:longitude":-2.537706,
+    "iso:country":"GB",
+    "lbl:latitude":51.455279,
+    "lbl:longitude":-2.537706,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Crew's Hole"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"0ca6571228a93e5f01c39091ad74f757",
+    "wof:hierarchy":[],
+    "wof:id":1444831365,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Crew's Hole",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.537705762880904,
+    51.45527870564925,
+    -2.537705762880904,
+    51.45527870564925
+],
+  "geometry": {"coordinates":[-2.5377057628809,51.45527870564925],"type":"Point"}
+}

--- a/data/144/483/136/5/1444831365.geojson
+++ b/data/144/483/136/5/1444831365.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"0ca6571228a93e5f01c39091ad74f757",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d9c90b870e6f023e997e89895ee08d96",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831365,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831365,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340897,
     "wof:name":"Crew's Hole",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.537705762880904,
+    -2.5377057628809,
     51.45527870564925,
-    -2.537705762880904,
+    -2.5377057628809,
     51.45527870564925
 ],
   "geometry": {"coordinates":[-2.5377057628809,51.45527870564925],"type":"Point"}

--- a/data/144/483/137/7/1444831377.geojson
+++ b/data/144/483/137/7/1444831377.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"f81591eb2b79682130d63aadc808543a",
-    "wof:hierarchy":[],
+    "wof:geomhash":"f13e27fc6e41c8fd58293e4c82654a6b",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831377,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831377,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340898,
     "wof:name":"St Anne's Park",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.540850102173687,
+    -2.54085010217369,
     51.45000605626615,
-    -2.540850102173687,
+    -2.54085010217369,
     51.45000605626615
 ],
   "geometry": {"coordinates":[-2.54085010217369,51.45000605626615],"type":"Point"}

--- a/data/144/483/137/7/1444831377.geojson
+++ b/data/144/483/137/7/1444831377.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831377,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.54085010217,51.4500060563,-2.54085010217,51.4500060563",
+    "geom:latitude":51.450006,
+    "geom:longitude":-2.54085,
+    "iso:country":"GB",
+    "lbl:latitude":51.450006,
+    "lbl:longitude":-2.54085,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "St Anne's Park"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"f81591eb2b79682130d63aadc808543a",
+    "wof:hierarchy":[],
+    "wof:id":1444831377,
+    "wof:lastmodified":1566334999,
+    "wof:name":"St Anne's Park",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.540850102173687,
+    51.45000605626615,
+    -2.540850102173687,
+    51.45000605626615
+],
+  "geometry": {"coordinates":[-2.54085010217369,51.45000605626615],"type":"Point"}
+}

--- a/data/144/483/138/7/1444831387.geojson
+++ b/data/144/483/138/7/1444831387.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831387,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.53862047977,51.4418821344,-2.53862047977,51.4418821344",
+    "geom:latitude":51.441882,
+    "geom:longitude":-2.53862,
+    "iso:country":"GB",
+    "lbl:latitude":51.441882,
+    "lbl:longitude":-2.53862,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Broom Hill"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"dbd03078df49fa514f284541591c9be9",
+    "wof:hierarchy":[],
+    "wof:id":1444831387,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Broom Hill",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.538620479766077,
+    51.44188213441329,
+    -2.538620479766077,
+    51.44188213441329
+],
+  "geometry": {"coordinates":[-2.53862047976608,51.44188213441329],"type":"Point"}
+}

--- a/data/144/483/138/7/1444831387.geojson
+++ b/data/144/483/138/7/1444831387.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"dbd03078df49fa514f284541591c9be9",
-    "wof:hierarchy":[],
+    "wof:geomhash":"9934eadf0011d2bc83c7266ec837e927",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831387,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831387,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340899,
     "wof:name":"Broom Hill",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.538620479766077,
+    -2.53862047976608,
     51.44188213441329,
-    -2.538620479766077,
+    -2.53862047976608,
     51.44188213441329
 ],
   "geometry": {"coordinates":[-2.53862047976608,51.44188213441329],"type":"Point"}

--- a/data/144/483/139/9/1444831399.geojson
+++ b/data/144/483/139/9/1444831399.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"3bae492a0496948f712a7773d66c3778",
-    "wof:hierarchy":[],
+    "wof:geomhash":"0f89d7098d66796d9da7654863adaa65",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831399,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831399,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340902,
     "wof:name":"Whiteway",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.531645763516632,
+    -2.53164576351663,
     51.46336462649871,
-    -2.531645763516632,
+    -2.53164576351663,
     51.46336462649871
 ],
   "geometry": {"coordinates":[-2.53164576351663,51.46336462649871],"type":"Point"}

--- a/data/144/483/139/9/1444831399.geojson
+++ b/data/144/483/139/9/1444831399.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831399,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.53164576352,51.4633646265,-2.53164576352,51.4633646265",
+    "geom:latitude":51.463365,
+    "geom:longitude":-2.531646,
+    "iso:country":"GB",
+    "lbl:latitude":51.463365,
+    "lbl:longitude":-2.531646,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Whiteway"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"3bae492a0496948f712a7773d66c3778",
+    "wof:hierarchy":[],
+    "wof:id":1444831399,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Whiteway",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.531645763516632,
+    51.46336462649871,
+    -2.531645763516632,
+    51.46336462649871
+],
+  "geometry": {"coordinates":[-2.53164576351663,51.46336462649871],"type":"Point"}
+}

--- a/data/144/483/141/1/1444831411.geojson
+++ b/data/144/483/141/1/1444831411.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831411,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.53381821612,51.447155722,-2.53381821612,51.447155722",
+    "geom:latitude":51.447156,
+    "geom:longitude":-2.533818,
+    "iso:country":"GB",
+    "lbl:latitude":51.447156,
+    "lbl:longitude":-2.533818,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Conham"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"7ff906c4b193fad78ebf9b2442b3f98d",
+    "wof:hierarchy":[],
+    "wof:id":1444831411,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Conham",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.533818216118918,
+    51.44715572196419,
+    -2.533818216118918,
+    51.44715572196419
+],
+  "geometry": {"coordinates":[-2.53381821611892,51.44715572196419],"type":"Point"}
+}

--- a/data/144/483/141/1/1444831411.geojson
+++ b/data/144/483/141/1/1444831411.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"7ff906c4b193fad78ebf9b2442b3f98d",
-    "wof:hierarchy":[],
+    "wof:geomhash":"867087d808c40c94363d1be0c3092e03",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831411,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831411,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340902,
     "wof:name":"Conham",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.533818216118918,
+    -2.53381821611892,
     51.44715572196419,
-    -2.533818216118918,
+    -2.53381821611892,
     51.44715572196419
 ],
   "geometry": {"coordinates":[-2.53381821611892,51.44715572196419],"type":"Point"}

--- a/data/144/483/142/1/1444831421.geojson
+++ b/data/144/483/142/1/1444831421.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831421,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.55782953435,51.4375701678,-2.55782953435,51.4375701678",
+    "geom:latitude":51.43757,
+    "geom:longitude":-2.55783,
+    "iso:country":"GB",
+    "lbl:latitude":51.43757,
+    "lbl:longitude":-2.557829,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Kensington Park"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"972b7bc85e1950c23fb1c8c698ef2c20",
+    "wof:hierarchy":[],
+    "wof:id":1444831421,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Kensington Park",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.557829534354713,
+    51.437570167771995,
+    -2.557829534354713,
+    51.437570167771995
+],
+  "geometry": {"coordinates":[-2.55782953435471,51.43757016777199],"type":"Point"}
+}

--- a/data/144/483/142/1/1444831421.geojson
+++ b/data/144/483/142/1/1444831421.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"972b7bc85e1950c23fb1c8c698ef2c20",
-    "wof:hierarchy":[],
+    "wof:geomhash":"b1d70abc00149ae51ed9c12b9e96c291",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831421,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831421,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340903,
     "wof:name":"Kensington Park",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.557829534354713,
-    51.437570167771995,
-    -2.557829534354713,
-    51.437570167771995
+    -2.55782953435471,
+    51.43757016777199,
+    -2.55782953435471,
+    51.43757016777199
 ],
   "geometry": {"coordinates":[-2.55782953435471,51.43757016777199],"type":"Point"}
 }

--- a/data/144/483/143/1/1444831431.geojson
+++ b/data/144/483/143/1/1444831431.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831431,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.57057840094,51.4301925486,-2.57057840094,51.4301925486",
+    "geom:latitude":51.430193,
+    "geom:longitude":-2.570578,
+    "iso:country":"GB",
+    "lbl:latitude":51.430192,
+    "lbl:longitude":-2.570578,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Knowle Park"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"50cc281c18d1f9e47f74a8c573708361",
+    "wof:hierarchy":[],
+    "wof:id":1444831431,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Knowle Park",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.570578400941813,
+    51.43019254863213,
+    -2.570578400941813,
+    51.43019254863213
+],
+  "geometry": {"coordinates":[-2.57057840094181,51.43019254863213],"type":"Point"}
+}

--- a/data/144/483/143/1/1444831431.geojson
+++ b/data/144/483/143/1/1444831431.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"50cc281c18d1f9e47f74a8c573708361",
-    "wof:hierarchy":[],
+    "wof:geomhash":"35779a218ce839d3f074faef166cb539",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831431,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831431,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340904,
     "wof:name":"Knowle Park",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.570578400941813,
+    -2.57057840094181,
     51.43019254863213,
-    -2.570578400941813,
+    -2.57057840094181,
     51.43019254863213
 ],
   "geometry": {"coordinates":[-2.57057840094181,51.43019254863213],"type":"Point"}

--- a/data/144/483/143/9/1444831439.geojson
+++ b/data/144/483/143/9/1444831439.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"dece2fae5f68a42453899fe3a6b9d175",
-    "wof:hierarchy":[],
+    "wof:geomhash":"bf4506d27c527e45e8338204b3d6097c",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831439,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831439,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340907,
     "wof:name":"Upper Knowle",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.562860477223166,
+    -2.56286047722317,
     51.43603771761716,
-    -2.562860477223166,
+    -2.56286047722317,
     51.43603771761716
 ],
   "geometry": {"coordinates":[-2.56286047722317,51.43603771761716],"type":"Point"}

--- a/data/144/483/143/9/1444831439.geojson
+++ b/data/144/483/143/9/1444831439.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831439,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.56286047722,51.4360377176,-2.56286047722,51.4360377176",
+    "geom:latitude":51.436038,
+    "geom:longitude":-2.56286,
+    "iso:country":"GB",
+    "lbl:latitude":51.436038,
+    "lbl:longitude":-2.56286,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Upper Knowle"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"dece2fae5f68a42453899fe3a6b9d175",
+    "wof:hierarchy":[],
+    "wof:id":1444831439,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Upper Knowle",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.562860477223166,
+    51.43603771761716,
+    -2.562860477223166,
+    51.43603771761716
+],
+  "geometry": {"coordinates":[-2.56286047722317,51.43603771761716],"type":"Point"}
+}

--- a/data/144/483/145/5/1444831455.geojson
+++ b/data/144/483/145/5/1444831455.geojson
@@ -1,0 +1,55 @@
+{
+  "id": 1444831455,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.58892990845,51.4282321177,-2.58892990845,51.4282321177",
+    "geom:latitude":51.428232,
+    "geom:longitude":-2.58893,
+    "iso:country":"GB",
+    "lbl:latitude":51.428232,
+    "lbl:longitude":-2.58893,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:note":"Lower Knowle seems to be largely deprecated",
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Knowle West"
+    ],
+    "name:eng_x_variant":[
+        "Lower Knowle"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"cfae7f514b383f3b776fd6cd492c377e",
+    "wof:hierarchy":[],
+    "wof:id":1444831455,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Knowle West",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.5889299084506,
+    51.42823211765405,
+    -2.5889299084506,
+    51.42823211765405
+],
+  "geometry": {"coordinates":[-2.5889299084506,51.42823211765405],"type":"Point"}
+}

--- a/data/144/483/145/5/1444831455.geojson
+++ b/data/144/483/145/5/1444831455.geojson
@@ -30,15 +30,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
     "wof:geomhash":"cfae7f514b383f3b776fd6cd492c377e",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831455,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831455,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340908,
     "wof:name":"Knowle West",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],

--- a/data/144/483/146/5/1444831465.geojson
+++ b/data/144/483/146/5/1444831465.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"778916c586411c9008d0de9b40938e74",
-    "wof:hierarchy":[],
+    "wof:geomhash":"ca6eb84d4c655015708007f9753ce7ad",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831465,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831465,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340909,
     "wof:name":"Filwood Park",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.583155758112945,
+    -2.58315575811294,
     51.42677064701513,
-    -2.583155758112945,
+    -2.58315575811294,
     51.42677064701513
 ],
   "geometry": {"coordinates":[-2.58315575811294,51.42677064701513],"type":"Point"}

--- a/data/144/483/146/5/1444831465.geojson
+++ b/data/144/483/146/5/1444831465.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831465,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.58315575811,51.426770647,-2.58315575811,51.426770647",
+    "geom:latitude":51.426771,
+    "geom:longitude":-2.583156,
+    "iso:country":"GB",
+    "lbl:latitude":51.426771,
+    "lbl:longitude":-2.583156,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":16.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Filwood Park"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"778916c586411c9008d0de9b40938e74",
+    "wof:hierarchy":[],
+    "wof:id":1444831465,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Filwood Park",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.583155758112945,
+    51.42677064701513,
+    -2.583155758112945,
+    51.42677064701513
+],
+  "geometry": {"coordinates":[-2.58315575811294,51.42677064701513],"type":"Point"}
+}

--- a/data/144/483/148/1/1444831481.geojson
+++ b/data/144/483/148/1/1444831481.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"06db7cd660613a4c9c9b07b7c2f9ad53",
-    "wof:hierarchy":[],
+    "wof:geomhash":"b0b3f96d4c1dc4cdca299ce57d86a7d4",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831481,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831481,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340909,
     "wof:name":"Inn's Court",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +59,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.594761228593579,
-    51.419177376589055,
-    -2.594761228593579,
-    51.419177376589055
+    -2.59476122859358,
+    51.41917737658905,
+    -2.59476122859358,
+    51.41917737658905
 ],
   "geometry": {"coordinates":[-2.59476122859358,51.41917737658905],"type":"Point"}
 }

--- a/data/144/483/148/1/1444831481.geojson
+++ b/data/144/483/148/1/1444831481.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831481,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.59476122859,51.4191773766,-2.59476122859,51.4191773766",
+    "geom:latitude":51.419177,
+    "geom:longitude":-2.594761,
+    "iso:country":"GB",
+    "lbl:latitude":51.419177,
+    "lbl:longitude":-2.594761,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Inn's Court"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"06db7cd660613a4c9c9b07b7c2f9ad53",
+    "wof:hierarchy":[],
+    "wof:id":1444831481,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Inn's Court",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.594761228593579,
+    51.419177376589055,
+    -2.594761228593579,
+    51.419177376589055
+],
+  "geometry": {"coordinates":[-2.59476122859358,51.41917737658905],"type":"Point"}
+}

--- a/data/144/483/148/9/1444831489.geojson
+++ b/data/144/483/148/9/1444831489.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831489,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.58675745585,51.4382472915,-2.58675745585,51.4382472915",
+    "geom:latitude":51.438247,
+    "geom:longitude":-2.586757,
+    "iso:country":"GB",
+    "lbl:latitude":51.438247,
+    "lbl:longitude":-2.586757,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Windmill Hill"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"0fb141aefcbbc7b73143e7e3c1151ffe",
+    "wof:hierarchy":[],
+    "wof:id":1444831489,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Windmill Hill",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.586757455848313,
+    51.43824729150759,
+    -2.586757455848313,
+    51.43824729150759
+],
+  "geometry": {"coordinates":[-2.58675745584831,51.43824729150759],"type":"Point"}
+}

--- a/data/144/483/148/9/1444831489.geojson
+++ b/data/144/483/148/9/1444831489.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"0fb141aefcbbc7b73143e7e3c1151ffe",
-    "wof:hierarchy":[],
+    "wof:geomhash":"81023f531137f37253c68b0dcb7d456a",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831489,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831489,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340912,
     "wof:name":"Windmill Hill",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.586757455848313,
+    -2.58675745584831,
     51.43824729150759,
-    -2.586757455848313,
+    -2.58675745584831,
     51.43824729150759
 ],
   "geometry": {"coordinates":[-2.58675745584831,51.43824729150759],"type":"Point"}

--- a/data/144/483/150/1/1444831501.geojson
+++ b/data/144/483/150/1/1444831501.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"4d4a81e8728418ec3fcb4cc2d7c8df51",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d6e9442df3b9070a81f36b577686682e",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831501,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831501,
-    "wof:lastmodified":1566334999,
+    "wof:lastmodified":1566340913,
     "wof:name":"Headley Park",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +59,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -2.607681604596648,
+    -2.60768160459665,
     51.42092429701251,
-    -2.607681604596648,
+    -2.60768160459665,
     51.42092429701251
 ],
   "geometry": {"coordinates":[-2.60768160459665,51.42092429701251],"type":"Point"}

--- a/data/144/483/150/1/1444831501.geojson
+++ b/data/144/483/150/1/1444831501.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831501,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.6076816046,51.420924297,-2.6076816046,51.420924297",
+    "geom:latitude":51.420924,
+    "geom:longitude":-2.607682,
+    "iso:country":"GB",
+    "lbl:latitude":51.420924,
+    "lbl:longitude":-2.607682,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Headley Park"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"4d4a81e8728418ec3fcb4cc2d7c8df51",
+    "wof:hierarchy":[],
+    "wof:id":1444831501,
+    "wof:lastmodified":1566334999,
+    "wof:name":"Headley Park",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.607681604596648,
+    51.42092429701251,
+    -2.607681604596648,
+    51.42092429701251
+],
+  "geometry": {"coordinates":[-2.60768160459665,51.42092429701251],"type":"Point"}
+}

--- a/data/144/483/151/1/1444831511.geojson
+++ b/data/144/483/151/1/1444831511.geojson
@@ -26,15 +26,32 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698531,
+        102191581,
+        85633159,
+        404227469,
+        1175612699,
+        1360698747
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"8598ba3e9c1a97c58b59ae67172dc4f2",
-    "wof:hierarchy":[],
+    "wof:geomhash":"e77dfffad16b16938fa57d127119fe70",
+    "wof:hierarchy":[
+        {
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698747,
+            "locality_id":1175612699,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444831511,
+            "region_id":1360698531
+        }
+    ],
     "wof:id":1444831511,
-    "wof:lastmodified":1566335000,
+    "wof:lastmodified":1566340914,
     "wof:name":"HIGHRIDGE",
-    "wof:parent_id":-1,
+    "wof:parent_id":1175612699,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -43,9 +60,9 @@
 },
   "bbox": [
     -2.62751952704384,
-    51.418000841535445,
+    51.41800084153545,
     -2.62751952704384,
-    51.418000841535445
+    51.41800084153545
 ],
   "geometry": {"coordinates":[-2.62751952704384,51.41800084153545],"type":"Point"}
 }

--- a/data/144/483/151/1/1444831511.geojson
+++ b/data/144/483/151/1/1444831511.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444831511,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-2.62751952704,51.4180008415,-2.62751952704,51.4180008415",
+    "geom:latitude":51.418001,
+    "geom:longitude":-2.62752,
+    "iso:country":"GB",
+    "lbl:latitude":51.418001,
+    "lbl:longitude":-2.62752,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "HIGHRIDGE"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"8598ba3e9c1a97c58b59ae67172dc4f2",
+    "wof:hierarchy":[],
+    "wof:id":1444831511,
+    "wof:lastmodified":1566335000,
+    "wof:name":"HIGHRIDGE",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -2.62751952704384,
+    51.418000841535445,
+    -2.62751952704384,
+    51.418000841535445
+],
+  "geometry": {"coordinates":[-2.62751952704384,51.41800084153545],"type":"Point"}
+}

--- a/data/144/483/619/3/1444836193.geojson
+++ b/data/144/483/619/3/1444836193.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836193,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.3255140745,51.523073462,-3.3255140745,51.523073462",
+    "geom:latitude":51.523073,
+    "geom:longitude":-3.325514,
+    "iso:country":"GB",
+    "lbl:latitude":51.523073,
+    "lbl:longitude":-3.325514,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Creigiau"
+    ],
+    "name:eng_x_preferred":[
+        "Creigiau"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"d16bdcfed740c6169b23ae6836c63195",
+    "wof:hierarchy":[],
+    "wof:id":1444836193,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Creigiau",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.325514074499565,
+    51.52307346204922,
+    -3.325514074499565,
+    51.52307346204922
+],
+  "geometry": {"coordinates":[-3.32551407449956,51.52307346204922],"type":"Point"}
+}

--- a/data/144/483/619/3/1444836193.geojson
+++ b/data/144/483/619/3/1444836193.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887607,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"d16bdcfed740c6169b23ae6836c63195",
-    "wof:hierarchy":[],
+    "wof:geomhash":"2c4391db6f240204c32d0bcd644777c6",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887607,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836193,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836193,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566340227,
     "wof:name":"Creigiau",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887607,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.325514074499565,
+    -3.32551407449956,
     51.52307346204922,
-    -3.325514074499565,
+    -3.32551407449956,
     51.52307346204922
 ],
   "geometry": {"coordinates":[-3.32551407449956,51.52307346204922],"type":"Point"}

--- a/data/144/483/620/9/1444836209.geojson
+++ b/data/144/483/620/9/1444836209.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836209,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.29821990183,51.5299442367,-3.29821990183,51.5299442367",
+    "geom:latitude":51.529944,
+    "geom:longitude":-3.29822,
+    "iso:country":"GB",
+    "lbl:latitude":51.529944,
+    "lbl:longitude":-3.29822,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Pentyrch"
+    ],
+    "name:eng_x_preferred":[
+        "Pentyrch"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"ef29e41e938c2e2738caaae337799e57",
+    "wof:hierarchy":[],
+    "wof:id":1444836209,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Pentyrch",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.298219901830879,
+    51.52994423666494,
+    -3.298219901830879,
+    51.52994423666494
+],
+  "geometry": {"coordinates":[-3.29821990183088,51.52994423666494],"type":"Point"}
+}

--- a/data/144/483/620/9/1444836209.geojson
+++ b/data/144/483/620/9/1444836209.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887607,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"ef29e41e938c2e2738caaae337799e57",
-    "wof:hierarchy":[],
+    "wof:geomhash":"45790254d6033750007d1fc3f724984d",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887607,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836209,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836209,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566340228,
     "wof:name":"Pentyrch",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887607,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.298219901830879,
+    -3.29821990183088,
     51.52994423666494,
-    -3.298219901830879,
+    -3.29821990183088,
     51.52994423666494
 ],
   "geometry": {"coordinates":[-3.29821990183088,51.52994423666494],"type":"Point"}

--- a/data/144/483/622/1/1444836221.geojson
+++ b/data/144/483/622/1/1444836221.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887607,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"d67c1641b2015a28a6c93652a52ed00e",
-    "wof:hierarchy":[],
+    "wof:geomhash":"a7419aa466c719ce721bf4a5e799790a",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887607,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836221,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836221,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566340229,
     "wof:name":"Gwaelod-y-garth",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887607,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,10 +64,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.276476116476371,
-    51.546173658200516,
-    -3.276476116476371,
-    51.546173658200516
+    -3.27647611647637,
+    51.54617365820052,
+    -3.27647611647637,
+    51.54617365820052
 ],
   "geometry": {"coordinates":[-3.27647611647637,51.54617365820052],"type":"Point"}
 }

--- a/data/144/483/622/1/1444836221.geojson
+++ b/data/144/483/622/1/1444836221.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836221,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.27647611648,51.5461736582,-3.27647611648,51.5461736582",
+    "geom:latitude":51.546174,
+    "geom:longitude":-3.276476,
+    "iso:country":"GB",
+    "lbl:latitude":51.546174,
+    "lbl:longitude":-3.276476,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Gwaelod-y-garth"
+    ],
+    "name:eng_x_preferred":[
+        "Gwaelod-y-garth"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"d67c1641b2015a28a6c93652a52ed00e",
+    "wof:hierarchy":[],
+    "wof:id":1444836221,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Gwaelod-y-garth",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.276476116476371,
+    51.546173658200516,
+    -3.276476116476371,
+    51.546173658200516
+],
+  "geometry": {"coordinates":[-3.27647611647637,51.54617365820052],"type":"Point"}
+}

--- a/data/144/483/623/3/1444836233.geojson
+++ b/data/144/483/623/3/1444836233.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836233,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.26182767161,51.526882776,-3.26182767161,51.526882776",
+    "geom:latitude":51.526883,
+    "geom:longitude":-3.261828,
+    "iso:country":"GB",
+    "lbl:latitude":51.526883,
+    "lbl:longitude":-3.261828,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Treforgan"
+    ],
+    "name:eng_x_preferred":[
+        "Morganstown"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"0c600c7d27d119a3684c87384480d03b",
+    "wof:hierarchy":[],
+    "wof:id":1444836233,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Morganstown",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.261827671605966,
+    51.526882776041866,
+    -3.261827671605966,
+    51.526882776041866
+],
+  "geometry": {"coordinates":[-3.26182767160597,51.52688277604187],"type":"Point"}
+}

--- a/data/144/483/623/3/1444836233.geojson
+++ b/data/144/483/623/3/1444836233.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887601,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"0c600c7d27d119a3684c87384480d03b",
-    "wof:hierarchy":[],
+    "wof:geomhash":"a25bcd5bfef4c875d6934eb60599e1e3",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887601,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836233,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836233,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566340229,
     "wof:name":"Morganstown",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887601,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,10 +64,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.261827671605966,
-    51.526882776041866,
-    -3.261827671605966,
-    51.526882776041866
+    -3.26182767160597,
+    51.52688277604187,
+    -3.26182767160597,
+    51.52688277604187
 ],
   "geometry": {"coordinates":[-3.26182767160597,51.52688277604187],"type":"Point"}
 }

--- a/data/144/483/624/3/1444836243.geojson
+++ b/data/144/483/624/3/1444836243.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887629,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"68e930ae03e87d3c829c5956e57e66d7",
-    "wof:hierarchy":[],
+    "wof:geomhash":"6d5bb7373c2a91928d85e451fb954849",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887629,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836243,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836243,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566340232,
     "wof:name":"Tongwynlais",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887629,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.249696928197662,
+    -3.24969692819766,
     51.53051378802197,
-    -3.249696928197662,
+    -3.24969692819766,
     51.53051378802197
 ],
   "geometry": {"coordinates":[-3.24969692819766,51.53051378802197],"type":"Point"}

--- a/data/144/483/624/3/1444836243.geojson
+++ b/data/144/483/624/3/1444836243.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836243,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.2496969282,51.530513788,-3.2496969282,51.530513788",
+    "geom:latitude":51.530514,
+    "geom:longitude":-3.249697,
+    "iso:country":"GB",
+    "lbl:latitude":51.530514,
+    "lbl:longitude":-3.249697,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Tongwynlais"
+    ],
+    "name:eng_x_preferred":[
+        "Tongwynlais"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"68e930ae03e87d3c829c5956e57e66d7",
+    "wof:hierarchy":[],
+    "wof:id":1444836243,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Tongwynlais",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.249696928197662,
+    51.53051378802197,
+    -3.249696928197662,
+    51.53051378802197
+],
+  "geometry": {"coordinates":[-3.24969692819766,51.53051378802197],"type":"Point"}
+}

--- a/data/144/483/625/7/1444836257.geojson
+++ b/data/144/483/625/7/1444836257.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887601,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"7c9b990896acc5befdbfd862740f5bdc",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d22793ea86c534864e34f5c38033e6f0",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887601,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836257,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836257,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566340233,
     "wof:name":"Radyr",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887601,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,10 +64,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.255190095024063,
-    51.517625945490316,
-    -3.255190095024063,
-    51.517625945490316
+    -3.25519009502406,
+    51.51762594549032,
+    -3.25519009502406,
+    51.51762594549032
 ],
   "geometry": {"coordinates":[-3.25519009502406,51.51762594549032],"type":"Point"}
 }

--- a/data/144/483/625/7/1444836257.geojson
+++ b/data/144/483/625/7/1444836257.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836257,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.25519009502,51.5176259455,-3.25519009502,51.5176259455",
+    "geom:latitude":51.517626,
+    "geom:longitude":-3.25519,
+    "iso:country":"GB",
+    "lbl:latitude":51.517626,
+    "lbl:longitude":-3.25519,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":16.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Radyr"
+    ],
+    "name:eng_x_preferred":[
+        "Radyr"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"7c9b990896acc5befdbfd862740f5bdc",
+    "wof:hierarchy":[],
+    "wof:id":1444836257,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Radyr",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.255190095024063,
+    51.517625945490316,
+    -3.255190095024063,
+    51.517625945490316
+],
+  "geometry": {"coordinates":[-3.25519009502406,51.51762594549032],"type":"Point"}
+}

--- a/data/144/483/626/9/1444836269.geojson
+++ b/data/144/483/626/9/1444836269.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836269,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.213190257,51.525529972,-3.213190257,51.525529972",
+    "geom:latitude":51.52553,
+    "geom:longitude":-3.21319,
+    "iso:country":"GB",
+    "lbl:latitude":51.52553,
+    "lbl:longitude":-3.21319,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Rhiwbeina"
+    ],
+    "name:eng_x_preferred":[
+        "Rhiwbina"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"cef2029e7e34ee1ff7b5c020d878172d",
+    "wof:hierarchy":[],
+    "wof:id":1444836269,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Rhiwbina",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.213190256997196,
+    51.525529972049746,
+    -3.213190256997196,
+    51.525529972049746
+],
+  "geometry": {"coordinates":[-3.2131902569972,51.52552997204975],"type":"Point"}
+}

--- a/data/144/483/626/9/1444836269.geojson
+++ b/data/144/483/626/9/1444836269.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887617,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"cef2029e7e34ee1ff7b5c020d878172d",
-    "wof:hierarchy":[],
+    "wof:geomhash":"7ff00a0bb58a3085daec4715bcdeb966",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887617,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836269,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836269,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566340234,
     "wof:name":"Rhiwbina",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887617,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,10 +64,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.213190256997196,
-    51.525529972049746,
-    -3.213190256997196,
-    51.525529972049746
+    -3.2131902569972,
+    51.52552997204975,
+    -3.2131902569972,
+    51.52552997204975
 ],
   "geometry": {"coordinates":[-3.2131902569972,51.52552997204975],"type":"Point"}
 }

--- a/data/144/483/627/3/1444836273.geojson
+++ b/data/144/483/627/3/1444836273.geojson
@@ -26,15 +26,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887601,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
     "wof:geomhash":"f270156f808d5a9bd0de64046dca0c8f",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887601,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836273,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836273,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566340234,
     "wof:name":"Radyr North",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887601,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],

--- a/data/144/483/627/3/1444836273.geojson
+++ b/data/144/483/627/3/1444836273.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444836273,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.26165601014,51.5187297432,-3.26165601014,51.5187297432",
+    "geom:latitude":51.51873,
+    "geom:longitude":-3.261656,
+    "iso:country":"GB",
+    "lbl:latitude":51.51873,
+    "lbl:longitude":-3.261656,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Radyr North"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"f270156f808d5a9bd0de64046dca0c8f",
+    "wof:hierarchy":[],
+    "wof:id":1444836273,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Radyr North",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.26165601014264,
+    51.51872974324649,
+    -3.26165601014264,
+    51.51872974324649
+],
+  "geometry": {"coordinates":[-3.26165601014264,51.51872974324649],"type":"Point"}
+}

--- a/data/144/483/628/3/1444836283.geojson
+++ b/data/144/483/628/3/1444836283.geojson
@@ -26,15 +26,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887601,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
     "wof:geomhash":"eacb1310067a01fa4250d4d564fb7304",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887601,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836283,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836283,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566340237,
     "wof:name":"Radyr South",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887601,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],

--- a/data/144/483/628/3/1444836283.geojson
+++ b/data/144/483/628/3/1444836283.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444836283,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.24912472332,51.5138514668,-3.24912472332,51.5138514668",
+    "geom:latitude":51.513851,
+    "geom:longitude":-3.249125,
+    "iso:country":"GB",
+    "lbl:latitude":51.513851,
+    "lbl:longitude":-3.249125,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Radyr South"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"eacb1310067a01fa4250d4d564fb7304",
+    "wof:hierarchy":[],
+    "wof:id":1444836283,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Radyr South",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.24912472331991,
+    51.5138514668013,
+    -3.24912472331991,
+    51.5138514668013
+],
+  "geometry": {"coordinates":[-3.24912472331991,51.5138514668013],"type":"Point"}
+}

--- a/data/144/483/629/5/1444836295.geojson
+++ b/data/144/483/629/5/1444836295.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887635,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"ab9b0737116d61c8eb0a0957a02d33a0",
-    "wof:hierarchy":[],
+    "wof:geomhash":"68bfaf9e9361c3c3de901e71b4874cf0",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887635,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836295,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836295,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566340238,
     "wof:name":"Whitchurch",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887635,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,10 +64,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.223947708698901,
-    51.515881178133036,
-    -3.223947708698901,
-    51.515881178133036
+    -3.2239477086989,
+    51.51588117813304,
+    -3.2239477086989,
+    51.51588117813304
 ],
   "geometry": {"coordinates":[-3.2239477086989,51.51588117813304],"type":"Point"}
 }

--- a/data/144/483/629/5/1444836295.geojson
+++ b/data/144/483/629/5/1444836295.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836295,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.2239477087,51.5158811781,-3.2239477087,51.5158811781",
+    "geom:latitude":51.515881,
+    "geom:longitude":-3.223948,
+    "iso:country":"GB",
+    "lbl:latitude":51.515881,
+    "lbl:longitude":-3.223948,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Yr Eglwys Newydd"
+    ],
+    "name:eng_x_preferred":[
+        "Whitchurch"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"ab9b0737116d61c8eb0a0957a02d33a0",
+    "wof:hierarchy":[],
+    "wof:id":1444836295,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Whitchurch",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.223947708698901,
+    51.515881178133036,
+    -3.223947708698901,
+    51.515881178133036
+],
+  "geometry": {"coordinates":[-3.2239477086989,51.51588117813304],"type":"Point"}
+}

--- a/data/144/483/638/3/1444836383.geojson
+++ b/data/144/483/638/3/1444836383.geojson
@@ -32,15 +32,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887589,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"66b6f8d0395c2fb1e0f2cc0a98cd0361",
-    "wof:hierarchy":[],
+    "wof:geomhash":"d724e9fabf8a8f7738e3fb9747dcac07",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887589,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836383,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836383,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566340239,
     "wof:name":"Lisvane",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887589,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -48,9 +67,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.177026908723384,
+    -3.17702690872338,
     51.54031963285012,
-    -3.177026908723384,
+    -3.17702690872338,
     51.54031963285012
 ],
   "geometry": {"coordinates":[-3.17702690872338,51.54031963285012],"type":"Point"}

--- a/data/144/483/638/3/1444836383.geojson
+++ b/data/144/483/638/3/1444836383.geojson
@@ -1,0 +1,57 @@
+{
+  "id": 1444836383,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.17702690872,51.5403196329,-3.17702690872,51.5403196329",
+    "geom:latitude":51.54032,
+    "geom:longitude":-3.177027,
+    "iso:country":"GB",
+    "lbl:latitude":51.54032,
+    "lbl:longitude":-3.177027,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Llys-faen"
+    ],
+    "name:cym_x_variant":[
+        "Llysfaen"
+    ],
+    "name:eng_x_preferred":[
+        "Lisvane"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"66b6f8d0395c2fb1e0f2cc0a98cd0361",
+    "wof:hierarchy":[],
+    "wof:id":1444836383,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Lisvane",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.177026908723384,
+    51.54031963285012,
+    -3.177026908723384,
+    51.54031963285012
+],
+  "geometry": {"coordinates":[-3.17702690872338,51.54031963285012],"type":"Point"}
+}

--- a/data/144/483/644/9/1444836449.geojson
+++ b/data/144/483/644/9/1444836449.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836449,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.1406346785,51.5357995966,-3.1406346785,51.5357995966",
+    "geom:latitude":51.5358,
+    "geom:longitude":-3.140635,
+    "iso:country":"GB",
+    "lbl:latitude":51.5358,
+    "lbl:longitude":-3.140635,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Pontprennau"
+    ],
+    "name:eng_x_preferred":[
+        "Pontprennau"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"25e2025ca6805f0dc57e8c3da5ce6c9e",
+    "wof:hierarchy":[],
+    "wof:id":1444836449,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Pontprennau",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.14063467849847,
+    51.535799596597265,
+    -3.14063467849847,
+    51.535799596597265
+],
+  "geometry": {"coordinates":[-3.14063467849847,51.53579959659726],"type":"Point"}
+}

--- a/data/144/483/644/9/1444836449.geojson
+++ b/data/144/483/644/9/1444836449.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887611,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"25e2025ca6805f0dc57e8c3da5ce6c9e",
-    "wof:hierarchy":[],
+    "wof:geomhash":"af7c3a5086a1cb9c8720a22bf62ff692",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887611,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836449,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836449,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566340239,
     "wof:name":"Pontprennau",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887611,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -46,9 +65,9 @@
 },
   "bbox": [
     -3.14063467849847,
-    51.535799596597265,
+    51.53579959659726,
     -3.14063467849847,
-    51.535799596597265
+    51.53579959659726
 ],
   "geometry": {"coordinates":[-3.14063467849847,51.53579959659726],"type":"Point"}
 }

--- a/data/144/483/645/7/1444836457.geojson
+++ b/data/144/483/645/7/1444836457.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887605,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"09046dc21ba8acd4438b1a725f253652",
-    "wof:hierarchy":[],
+    "wof:geomhash":"e039b83fddede0a72765c92714824911",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887605,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836457,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836457,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566340242,
     "wof:name":"Pentwyn",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887605,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,10 +64,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.146356727275971,
-    51.525796976021226,
-    -3.146356727275971,
-    51.525796976021226
+    -3.14635672727597,
+    51.52579697602123,
+    -3.14635672727597,
+    51.52579697602123
 ],
   "geometry": {"coordinates":[-3.14635672727597,51.52579697602123],"type":"Point"}
 }

--- a/data/144/483/645/7/1444836457.geojson
+++ b/data/144/483/645/7/1444836457.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836457,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.14635672728,51.525796976,-3.14635672728,51.525796976",
+    "geom:latitude":51.525797,
+    "geom:longitude":-3.146357,
+    "iso:country":"GB",
+    "lbl:latitude":51.525797,
+    "lbl:longitude":-3.146357,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Pentwyn"
+    ],
+    "name:eng_x_preferred":[
+        "Pentwyn"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"09046dc21ba8acd4438b1a725f253652",
+    "wof:hierarchy":[],
+    "wof:id":1444836457,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Pentwyn",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.146356727275971,
+    51.525796976021226,
+    -3.146356727275971,
+    51.525796976021226
+],
+  "geometry": {"coordinates":[-3.14635672727597,51.52579697602123],"type":"Point"}
+}

--- a/data/144/483/646/9/1444836469.geojson
+++ b/data/144/483/646/9/1444836469.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836469,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.11042226095,51.5289653036,-3.11042226095,51.5289653036",
+    "geom:latitude":51.528965,
+    "geom:longitude":-3.110422,
+    "iso:country":"GB",
+    "lbl:latitude":51.528965,
+    "lbl:longitude":-3.110422,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Pentre Llaneirwg"
+    ],
+    "name:eng_x_preferred":[
+        "Old Saint Mellons"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"7886500c55f649ea75dfd4f4d11ab03c",
+    "wof:hierarchy":[],
+    "wof:id":1444836469,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Old Saint Mellons",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.110422260953258,
+    51.528965303622016,
+    -3.110422260953258,
+    51.528965303622016
+],
+  "geometry": {"coordinates":[-3.11042226095326,51.52896530362202],"type":"Point"}
+}

--- a/data/144/483/646/9/1444836469.geojson
+++ b/data/144/483/646/9/1444836469.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887603,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"7886500c55f649ea75dfd4f4d11ab03c",
-    "wof:hierarchy":[],
+    "wof:geomhash":"71be350b793c2149295f81587968c2d3",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887603,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836469,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836469,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566340243,
     "wof:name":"Old Saint Mellons",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887603,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,10 +64,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.110422260953258,
-    51.528965303622016,
-    -3.110422260953258,
-    51.528965303622016
+    -3.11042226095326,
+    51.52896530362202,
+    -3.11042226095326,
+    51.52896530362202
 ],
   "geometry": {"coordinates":[-3.11042226095326,51.52896530362202],"type":"Point"}
 }

--- a/data/144/483/647/9/1444836479.geojson
+++ b/data/144/483/647/9/1444836479.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887631,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"59f295e0f91c42b27ea45105f5aab081",
-    "wof:hierarchy":[],
+    "wof:geomhash":"681927e3997a48b93aa34c26a4c08be4",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887631,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836479,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836479,
-    "wof:lastmodified":1566334997,
+    "wof:lastmodified":1566340244,
     "wof:name":"Llaneurwg",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887631,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,10 +64,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.098062635593854,
-    51.526295377853856,
-    -3.098062635593854,
-    51.526295377853856
+    -3.09806263559385,
+    51.52629537785386,
+    -3.09806263559385,
+    51.52629537785386
 ],
   "geometry": {"coordinates":[-3.09806263559385,51.52629537785386],"type":"Point"}
 }

--- a/data/144/483/647/9/1444836479.geojson
+++ b/data/144/483/647/9/1444836479.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836479,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.09806263559,51.5262953779,-3.09806263559,51.5262953779",
+    "geom:latitude":51.526295,
+    "geom:longitude":-3.098063,
+    "iso:country":"GB",
+    "lbl:latitude":51.526295,
+    "lbl:longitude":-3.098063,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Llaneurwg"
+    ],
+    "name:eng_x_preferred":[
+        "Saint Mellons"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"59f295e0f91c42b27ea45105f5aab081",
+    "wof:hierarchy":[],
+    "wof:id":1444836479,
+    "wof:lastmodified":1566334997,
+    "wof:name":"Llaneurwg",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.098062635593854,
+    51.526295377853856,
+    -3.098062635593854,
+    51.526295377853856
+],
+  "geometry": {"coordinates":[-3.09806263559385,51.52629537785386],"type":"Point"}
+}

--- a/data/144/483/649/1/1444836491.geojson
+++ b/data/144/483/649/1/1444836491.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444836491,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.10573018096,51.5182134518,-3.10573018096,51.5182134518",
+    "geom:latitude":51.518213,
+    "geom:longitude":-3.10573,
+    "iso:country":"GB",
+    "lbl:latitude":51.518213,
+    "lbl:longitude":-3.10573,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Trowbridge"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"e77e82265127f69b6a7b57d9d3328ea4",
+    "wof:hierarchy":[],
+    "wof:id":1444836491,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Trowbridge",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.105730180955707,
+    51.518213451839436,
+    -3.105730180955707,
+    51.518213451839436
+],
+  "geometry": {"coordinates":[-3.10573018095571,51.51821345183944],"type":"Point"}
+}

--- a/data/144/483/649/1/1444836491.geojson
+++ b/data/144/483/649/1/1444836491.geojson
@@ -26,15 +26,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887631,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"e77e82265127f69b6a7b57d9d3328ea4",
-    "wof:hierarchy":[],
+    "wof:geomhash":"f83bf6d95c6c4613f6d50dfdbcab934d",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887631,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836491,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836491,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340244,
     "wof:name":"Trowbridge",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887631,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +61,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.105730180955707,
-    51.518213451839436,
-    -3.105730180955707,
-    51.518213451839436
+    -3.10573018095571,
+    51.51821345183944,
+    -3.10573018095571,
+    51.51821345183944
 ],
   "geometry": {"coordinates":[-3.10573018095571,51.51821345183944],"type":"Point"}
 }

--- a/data/144/483/650/3/1444836503.geojson
+++ b/data/144/483/650/3/1444836503.geojson
@@ -32,15 +32,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887599,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"3367ade55d6dbb1d2071f5c5595cd47b",
-    "wof:hierarchy":[],
+    "wof:geomhash":"8ee5f48029b510c23dbcef80cc9be361",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887599,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836503,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836503,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340247,
     "wof:name":"Llanrumney",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887599,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -48,9 +67,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.124956264848114,
+    -3.12495626484811,
     51.52024297100185,
-    -3.124956264848114,
+    -3.12495626484811,
     51.52024297100185
 ],
   "geometry": {"coordinates":[-3.12495626484811,51.52024297100185],"type":"Point"}

--- a/data/144/483/650/3/1444836503.geojson
+++ b/data/144/483/650/3/1444836503.geojson
@@ -1,0 +1,57 @@
+{
+  "id": 1444836503,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.12495626485,51.520242971,-3.12495626485,51.520242971",
+    "geom:latitude":51.520243,
+    "geom:longitude":-3.124956,
+    "iso:country":"GB",
+    "lbl:latitude":51.520243,
+    "lbl:longitude":-3.124956,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Llanrhymni"
+    ],
+    "name:cym_x_variant":[
+        "Llanrhymney"
+    ],
+    "name:eng_x_preferred":[
+        "Llanrumney"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"3367ade55d6dbb1d2071f5c5595cd47b",
+    "wof:hierarchy":[],
+    "wof:id":1444836503,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Llanrumney",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.124956264848114,
+    51.52024297100185,
+    -3.124956264848114,
+    51.52024297100185
+],
+  "geometry": {"coordinates":[-3.12495626484811,51.52024297100185],"type":"Point"}
+}

--- a/data/144/483/651/3/1444836513.geojson
+++ b/data/144/483/651/3/1444836513.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444836513,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.1045857712,51.5129434088,-3.1045857712,51.5129434088",
+    "geom:latitude":51.512943,
+    "geom:longitude":-3.104586,
+    "iso:country":"GB",
+    "lbl:latitude":51.512943,
+    "lbl:longitude":-3.104586,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Trowbridge Mawr"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"57bb3dae068ce51afbd68e4fc3938698",
+    "wof:hierarchy":[],
+    "wof:id":1444836513,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Trowbridge Mawr",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.104585771200207,
+    51.51294340876644,
+    -3.104585771200207,
+    51.51294340876644
+],
+  "geometry": {"coordinates":[-3.10458577120021,51.51294340876644],"type":"Point"}
+}

--- a/data/144/483/651/3/1444836513.geojson
+++ b/data/144/483/651/3/1444836513.geojson
@@ -26,15 +26,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887631,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"57bb3dae068ce51afbd68e4fc3938698",
-    "wof:hierarchy":[],
+    "wof:geomhash":"8686e7b1a1522d62ece81dbed5dc75a3",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887631,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836513,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836513,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340248,
     "wof:name":"Trowbridge Mawr",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887631,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.104585771200207,
+    -3.10458577120021,
     51.51294340876644,
-    -3.104585771200207,
+    -3.10458577120021,
     51.51294340876644
 ],
   "geometry": {"coordinates":[-3.10458577120021,51.51294340876644],"type":"Point"}

--- a/data/144/483/652/5/1444836525.geojson
+++ b/data/144/483/652/5/1444836525.geojson
@@ -32,15 +32,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887623,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"a521df20ff245d2b8cc8120b2a65bebd",
-    "wof:hierarchy":[],
+    "wof:geomhash":"0a55d297376cb854f4367a85903eea69",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887623,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836525,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836525,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340249,
     "wof:name":"Rumney",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887623,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -48,10 +67,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.122724665824888,
-    51.509560288124554,
-    -3.122724665824888,
-    51.509560288124554
+    -3.12272466582489,
+    51.50956028812455,
+    -3.12272466582489,
+    51.50956028812455
 ],
   "geometry": {"coordinates":[-3.12272466582489,51.50956028812455],"type":"Point"}
 }

--- a/data/144/483/652/5/1444836525.geojson
+++ b/data/144/483/652/5/1444836525.geojson
@@ -1,0 +1,57 @@
+{
+  "id": 1444836525,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.12272466582,51.5095602881,-3.12272466582,51.5095602881",
+    "geom:latitude":51.50956,
+    "geom:longitude":-3.122725,
+    "iso:country":"GB",
+    "lbl:latitude":51.50956,
+    "lbl:longitude":-3.122725,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Rhymni"
+    ],
+    "name:cym_x_variant":[
+        "Rhymney"
+    ],
+    "name:eng_x_preferred":[
+        "Rumney"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"a521df20ff245d2b8cc8120b2a65bebd",
+    "wof:hierarchy":[],
+    "wof:id":1444836525,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Rumney",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.122724665824888,
+    51.509560288124554,
+    -3.122724665824888,
+    51.509560288124554
+],
+  "geometry": {"coordinates":[-3.12272466582489,51.50956028812455],"type":"Point"}
+}

--- a/data/144/483/653/5/1444836535.geojson
+++ b/data/144/483/653/5/1444836535.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887575,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"564ab327ef77ca6f76ae2a4cdeacbac0",
-    "wof:hierarchy":[],
+    "wof:geomhash":"9e7a87151cdac1ad99a8158ccbeb717e",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887575,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836535,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836535,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340250,
     "wof:name":"Roath Park",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887575,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.175195853114583,
+    -3.17519585311458,
     51.50870556526234,
-    -3.175195853114583,
+    -3.17519585311458,
     51.50870556526234
 ],
   "geometry": {"coordinates":[-3.17519585311458,51.50870556526234],"type":"Point"}

--- a/data/144/483/653/5/1444836535.geojson
+++ b/data/144/483/653/5/1444836535.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836535,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.17519585311,51.5087055653,-3.17519585311,51.5087055653",
+    "geom:latitude":51.508706,
+    "geom:longitude":-3.175196,
+    "iso:country":"GB",
+    "lbl:latitude":51.508705,
+    "lbl:longitude":-3.175196,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Parc y Rhath"
+    ],
+    "name:eng_x_preferred":[
+        "Roath Park"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"564ab327ef77ca6f76ae2a4cdeacbac0",
+    "wof:hierarchy":[],
+    "wof:id":1444836535,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Roath Park",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.175195853114583,
+    51.50870556526234,
+    -3.175195853114583,
+    51.50870556526234
+],
+  "geometry": {"coordinates":[-3.17519585311458,51.50870556526234],"type":"Point"}
+}

--- a/data/144/483/654/7/1444836547.geojson
+++ b/data/144/483/654/7/1444836547.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836547,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.16741386678,51.5175369283,-3.16741386678,51.5175369283",
+    "geom:latitude":51.517537,
+    "geom:longitude":-3.167414,
+    "iso:country":"GB",
+    "lbl:latitude":51.517537,
+    "lbl:longitude":-3.167414,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Cyncoed"
+    ],
+    "name:eng_x_preferred":[
+        "Cyncoed"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"563770a0ebe51c984537e8c24e17db13",
+    "wof:hierarchy":[],
+    "wof:id":1444836547,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Cyncoed",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.16741386677718,
+    51.517536928286326,
+    -3.16741386677718,
+    51.517536928286326
+],
+  "geometry": {"coordinates":[-3.16741386677718,51.51753692828633],"type":"Point"}
+}

--- a/data/144/483/654/7/1444836547.geojson
+++ b/data/144/483/654/7/1444836547.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887575,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"563770a0ebe51c984537e8c24e17db13",
-    "wof:hierarchy":[],
+    "wof:geomhash":"993053775cfee814bb8e4a835433ba0f",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887575,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836547,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836547,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340253,
     "wof:name":"Cyncoed",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887575,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -46,9 +65,9 @@
 },
   "bbox": [
     -3.16741386677718,
-    51.517536928286326,
+    51.51753692828633,
     -3.16741386677718,
-    51.517536928286326
+    51.51753692828633
 ],
   "geometry": {"coordinates":[-3.16741386677718,51.51753692828633],"type":"Point"}
 }

--- a/data/144/483/655/9/1444836559.geojson
+++ b/data/144/483/655/9/1444836559.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836559,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.19190423554,51.5136912226,-3.19190423554,51.5136912226",
+    "geom:latitude":51.513691,
+    "geom:longitude":-3.191904,
+    "iso:country":"GB",
+    "lbl:latitude":51.513691,
+    "lbl:longitude":-3.191904,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Y Mynydd Bychan"
+    ],
+    "name:eng_x_preferred":[
+        "Heath"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"baba593eb0290aa568931667709460ba",
+    "wof:hierarchy":[],
+    "wof:id":1444836559,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Heath",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.191904235544889,
+    51.51369122258103,
+    -3.191904235544889,
+    51.51369122258103
+],
+  "geometry": {"coordinates":[-3.19190423554489,51.51369122258103],"type":"Point"}
+}

--- a/data/144/483/655/9/1444836559.geojson
+++ b/data/144/483/655/9/1444836559.geojson
@@ -29,15 +29,36 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698539,
+        102191581,
+        404451883,
+        85633159,
+        404227469,
+        1360757427,
+        1360887587,
+        1360698765
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"baba593eb0290aa568931667709460ba",
-    "wof:hierarchy":[],
+    "wof:geomhash":"f9534cba78f1a66dcef9804817112f64",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887587,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360698765,
+            "localadmin_id":404451883,
+            "locality_id":1360757427,
+            "macroregion_id":404227469,
+            "neighbourhood_id":1444836559,
+            "region_id":1360698539
+        }
+    ],
     "wof:id":1444836559,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340253,
     "wof:name":"Heath",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887587,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,9 +66,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.191904235544889,
+    -3.19190423554489,
     51.51369122258103,
-    -3.191904235544889,
+    -3.19190423554489,
     51.51369122258103
 ],
   "geometry": {"coordinates":[-3.19190423554489,51.51369122258103],"type":"Point"}

--- a/data/144/483/656/9/1444836569.geojson
+++ b/data/144/483/656/9/1444836569.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887595,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"c1cc053cccc0f074f7084b4fcfb590a0",
-    "wof:hierarchy":[],
+    "wof:geomhash":"6f43af632668d6c6fe8ab98d7eaf5b6b",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887595,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836569,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836569,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340254,
     "wof:name":"Llanishen",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887595,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.190759825789389,
+    -3.19075982578939,
     51.52942807459287,
-    -3.190759825789389,
+    -3.19075982578939,
     51.52942807459287
 ],
   "geometry": {"coordinates":[-3.19075982578939,51.52942807459287],"type":"Point"}

--- a/data/144/483/656/9/1444836569.geojson
+++ b/data/144/483/656/9/1444836569.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836569,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.19075982579,51.5294280746,-3.19075982579,51.5294280746",
+    "geom:latitude":51.529428,
+    "geom:longitude":-3.19076,
+    "iso:country":"GB",
+    "lbl:latitude":51.529428,
+    "lbl:longitude":-3.19076,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Llanisien"
+    ],
+    "name:eng_x_preferred":[
+        "Llanishen"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"c1cc053cccc0f074f7084b4fcfb590a0",
+    "wof:hierarchy":[],
+    "wof:id":1444836569,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Llanishen",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.190759825789389,
+    51.52942807459287,
+    -3.190759825789389,
+    51.52942807459287
+],
+  "geometry": {"coordinates":[-3.19075982578939,51.52942807459287],"type":"Point"}
+}

--- a/data/144/483/658/1/1444836581.geojson
+++ b/data/144/483/658/1/1444836581.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887621,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"e36386ee145f549648fbdc27caa9d8b8",
-    "wof:hierarchy":[],
+    "wof:geomhash":"1392d343dc2b2e1d74f649c3c4e3ecc8",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887621,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836581,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836581,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340255,
     "wof:name":"Roath",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887621,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.166097795558356,
+    -3.16609779555836,
     51.49228464345877,
-    -3.166097795558356,
+    -3.16609779555836,
     51.49228464345877
 ],
   "geometry": {"coordinates":[-3.16609779555836,51.49228464345877],"type":"Point"}

--- a/data/144/483/658/1/1444836581.geojson
+++ b/data/144/483/658/1/1444836581.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836581,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.16609779556,51.4922846435,-3.16609779556,51.4922846435",
+    "geom:latitude":51.492285,
+    "geom:longitude":-3.166098,
+    "iso:country":"GB",
+    "lbl:latitude":51.492285,
+    "lbl:longitude":-3.166098,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":16.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Y Rhath"
+    ],
+    "name:eng_x_preferred":[
+        "Roath"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"e36386ee145f549648fbdc27caa9d8b8",
+    "wof:hierarchy":[],
+    "wof:id":1444836581,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Roath",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.166097795558356,
+    51.49228464345877,
+    -3.166097795558356,
+    51.49228464345877
+],
+  "geometry": {"coordinates":[-3.16609779555836,51.49228464345877],"type":"Point"}
+}

--- a/data/144/483/658/9/1444836589.geojson
+++ b/data/144/483/658/9/1444836589.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887591,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"a5ceea77b11e016cdfcc92034120e1bb",
-    "wof:hierarchy":[],
+    "wof:geomhash":"79e1748d1018ef620fe98852b99df04a",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887591,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836589,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836589,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340257,
     "wof:name":"Llandaf",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887591,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,10 +64,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.225721543819925,
-    51.497058368615946,
-    -3.225721543819925,
-    51.497058368615946
+    -3.22572154381993,
+    51.49705836861595,
+    -3.22572154381993,
+    51.49705836861595
 ],
   "geometry": {"coordinates":[-3.22572154381993,51.49705836861595],"type":"Point"}
 }

--- a/data/144/483/658/9/1444836589.geojson
+++ b/data/144/483/658/9/1444836589.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836589,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.22572154382,51.4970583686,-3.22572154382,51.4970583686",
+    "geom:latitude":51.497058,
+    "geom:longitude":-3.225722,
+    "iso:country":"GB",
+    "lbl:latitude":51.497058,
+    "lbl:longitude":-3.225722,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":12.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Llandaf"
+    ],
+    "name:eng_x_preferred":[
+        "Llandaff"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"a5ceea77b11e016cdfcc92034120e1bb",
+    "wof:hierarchy":[],
+    "wof:id":1444836589,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Llandaf",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.225721543819925,
+    51.497058368615946,
+    -3.225721543819925,
+    51.497058368615946
+],
+  "geometry": {"coordinates":[-3.22572154381993,51.49705836861595],"type":"Point"}
+}

--- a/data/144/483/660/3/1444836603.geojson
+++ b/data/144/483/660/3/1444836603.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887593,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"ffc0ef01f1fd53e7968bef66e15e8653",
-    "wof:hierarchy":[],
+    "wof:geomhash":"8adcc5425a9e6048cb0ceed763261d0c",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887593,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836603,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836603,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340258,
     "wof:name":"Llandaff North",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887593,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.224348252113325,
+    -3.22434825211332,
     51.50396868541813,
-    -3.224348252113325,
+    -3.22434825211332,
     51.50396868541813
 ],
   "geometry": {"coordinates":[-3.22434825211332,51.50396868541813],"type":"Point"}

--- a/data/144/483/660/3/1444836603.geojson
+++ b/data/144/483/660/3/1444836603.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836603,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.22434825211,51.5039686854,-3.22434825211,51.5039686854",
+    "geom:latitude":51.503969,
+    "geom:longitude":-3.224348,
+    "iso:country":"GB",
+    "lbl:latitude":51.503969,
+    "lbl:longitude":-3.224348,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Ystum Taf"
+    ],
+    "name:eng_x_preferred":[
+        "Llandaff North"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"ffc0ef01f1fd53e7968bef66e15e8653",
+    "wof:hierarchy":[],
+    "wof:id":1444836603,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Llandaff North",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.224348252113325,
+    51.50396868541813,
+    -3.224348252113325,
+    51.50396868541813
+],
+  "geometry": {"coordinates":[-3.22434825211332,51.50396868541813],"type":"Point"}
+}

--- a/data/144/483/661/3/1444836613.geojson
+++ b/data/144/483/661/3/1444836613.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836613,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.25581952039,51.4939234465,-3.25581952039,51.4939234465",
+    "geom:latitude":51.493923,
+    "geom:longitude":-3.25582,
+    "iso:country":"GB",
+    "lbl:latitude":51.493923,
+    "lbl:longitude":-3.255819,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Pentrebane"
+    ],
+    "name:eng_x_preferred":[
+        "Pentrebane"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"95cba2bd329165012c6e7225b72813fc",
+    "wof:hierarchy":[],
+    "wof:id":1444836613,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Pentrebane",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.255819520389585,
+    51.49392344647465,
+    -3.255819520389585,
+    51.49392344647465
+],
+  "geometry": {"coordinates":[-3.25581952038958,51.49392344647465],"type":"Point"}
+}

--- a/data/144/483/661/3/1444836613.geojson
+++ b/data/144/483/661/3/1444836613.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887581,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"95cba2bd329165012c6e7225b72813fc",
-    "wof:hierarchy":[],
+    "wof:geomhash":"b0aeb30d11f9bc70307451194e5023a7",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887581,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836613,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836613,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340259,
     "wof:name":"Pentrebane",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887581,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.255819520389585,
+    -3.25581952038958,
     51.49392344647465,
-    -3.255819520389585,
+    -3.25581952038958,
     51.49392344647465
 ],
   "geometry": {"coordinates":[-3.25581952038958,51.49392344647465],"type":"Point"}

--- a/data/144/483/662/1/1444836621.geojson
+++ b/data/144/483/662/1/1444836621.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836621,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.24574871454,51.4952771893,-3.24574871454,51.4952771893",
+    "geom:latitude":51.495277,
+    "geom:longitude":-3.245749,
+    "iso:country":"GB",
+    "lbl:latitude":51.495277,
+    "lbl:longitude":-3.245749,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Tyllgoed"
+    ],
+    "name:eng_x_preferred":[
+        "Fairwater"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"0259692151ffe47e2f3380d9a7dfe07c",
+    "wof:hierarchy":[],
+    "wof:id":1444836621,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Fairwater",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.245748714541181,
+    51.49527718930313,
+    -3.245748714541181,
+    51.49527718930313
+],
+  "geometry": {"coordinates":[-3.24574871454118,51.49527718930313],"type":"Point"}
+}

--- a/data/144/483/662/1/1444836621.geojson
+++ b/data/144/483/662/1/1444836621.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887581,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"0259692151ffe47e2f3380d9a7dfe07c",
-    "wof:hierarchy":[],
+    "wof:geomhash":"e1907220b60ab161da8c2b8bd850e9ed",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887581,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836621,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836621,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340259,
     "wof:name":"Fairwater",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887581,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.245748714541181,
+    -3.24574871454118,
     51.49527718930313,
-    -3.245748714541181,
+    -3.24574871454118,
     51.49527718930313
 ],
   "geometry": {"coordinates":[-3.24574871454118,51.49527718930313],"type":"Point"}

--- a/data/144/483/663/7/1444836637.geojson
+++ b/data/144/483/663/7/1444836637.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836637,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.28065321208,51.5118038593,-3.28065321208,51.5118038593",
+    "geom:latitude":51.511804,
+    "geom:longitude":-3.280653,
+    "iso:country":"GB",
+    "lbl:latitude":51.511804,
+    "lbl:longitude":-3.280653,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Rhydlafar"
+    ],
+    "name:eng_x_preferred":[
+        "Rhydlafar"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"44c81e1d757d7666209e0ace8cc9a40e",
+    "wof:hierarchy":[],
+    "wof:id":1444836637,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Rhydlafar",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.280653212083943,
+    51.511803859347516,
+    -3.280653212083943,
+    51.511803859347516
+],
+  "geometry": {"coordinates":[-3.28065321208394,51.51180385934752],"type":"Point"}
+}

--- a/data/144/483/663/7/1444836637.geojson
+++ b/data/144/483/663/7/1444836637.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887627,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"44c81e1d757d7666209e0ace8cc9a40e",
-    "wof:hierarchy":[],
+    "wof:geomhash":"b2d2dab6d7ec59aa6fd3b892153b49cf",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887627,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836637,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836637,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340262,
     "wof:name":"Rhydlafar",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887627,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,10 +64,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.280653212083943,
-    51.511803859347516,
-    -3.280653212083943,
-    51.511803859347516
+    -3.28065321208394,
+    51.51180385934752,
+    -3.28065321208394,
+    51.51180385934752
 ],
   "geometry": {"coordinates":[-3.28065321208394,51.51180385934752],"type":"Point"}
 }

--- a/data/144/483/664/7/1444836647.geojson
+++ b/data/144/483/664/7/1444836647.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836647,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.26703473599,51.4878667363,-3.26703473599,51.4878667363",
+    "geom:latitude":51.487867,
+    "geom:longitude":-3.267035,
+    "iso:country":"GB",
+    "lbl:latitude":51.487867,
+    "lbl:longitude":-3.267035,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Sain Ffagan"
+    ],
+    "name:eng_x_preferred":[
+        "Saint Fagans"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"90818822272220749ce3cb65d698f740",
+    "wof:hierarchy":[],
+    "wof:id":1444836647,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Sain Ffagan",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.267034735993489,
+    51.487866736310345,
+    -3.267034735993489,
+    51.487866736310345
+],
+  "geometry": {"coordinates":[-3.26703473599349,51.48786673631034],"type":"Point"}
+}

--- a/data/144/483/664/7/1444836647.geojson
+++ b/data/144/483/664/7/1444836647.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887627,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"90818822272220749ce3cb65d698f740",
-    "wof:hierarchy":[],
+    "wof:geomhash":"43241309c8cfe33910d21d7e5f00e021",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887627,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836647,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836647,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340263,
     "wof:name":"Sain Ffagan",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887627,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,10 +64,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.267034735993489,
-    51.487866736310345,
-    -3.267034735993489,
-    51.487866736310345
+    -3.26703473599349,
+    51.48786673631034,
+    -3.26703473599349,
+    51.48786673631034
 ],
   "geometry": {"coordinates":[-3.26703473599349,51.48786673631034],"type":"Point"}
 }

--- a/data/144/483/665/5/1444836655.geojson
+++ b/data/144/483/665/5/1444836655.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887577,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
     "wof:geomhash":"3cb70d4a819112345669597325b89502",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887577,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836655,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836655,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340264,
     "wof:name":"Michaelston-super-Ely",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887577,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],

--- a/data/144/483/665/5/1444836655.geojson
+++ b/data/144/483/665/5/1444836655.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836655,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.26817914575,51.4738976082,-3.26817914575,51.4738976082",
+    "geom:latitude":51.473898,
+    "geom:longitude":-3.268179,
+    "iso:country":"GB",
+    "lbl:latitude":51.473898,
+    "lbl:longitude":-3.268179,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Llanfihangel-ar-Elai"
+    ],
+    "name:eng_x_preferred":[
+        "Michaelston-super-Ely"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"3cb70d4a819112345669597325b89502",
+    "wof:hierarchy":[],
+    "wof:id":1444836655,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Michaelston-super-Ely",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.26817914574899,
+    51.47389760819273,
+    -3.26817914574899,
+    51.47389760819273
+],
+  "geometry": {"coordinates":[-3.26817914574899,51.47389760819273],"type":"Point"}
+}

--- a/data/144/483/666/9/1444836669.geojson
+++ b/data/144/483/666/9/1444836669.geojson
@@ -1,0 +1,57 @@
+{
+  "id": 1444836669,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.25078411747,51.4788870737,-3.25078411747,51.4788870737",
+    "geom:latitude":51.478887,
+    "geom:longitude":-3.250784,
+    "iso:country":"GB",
+    "lbl:latitude":51.478887,
+    "lbl:longitude":-3.250784,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Trel\u00e1i"
+    ],
+    "name:cym_x_variant":[
+        "Tre-l\u00e1i"
+    ],
+    "name:eng_x_preferred":[
+        "Ely"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"df2b9683a394934e41b7034cddc13fce",
+    "wof:hierarchy":[],
+    "wof:id":1444836669,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Ely",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.250784117465384,
+    51.47888707370208,
+    -3.250784117465384,
+    51.47888707370208
+],
+  "geometry": {"coordinates":[-3.25078411746538,51.47888707370208],"type":"Point"}
+}

--- a/data/144/483/666/9/1444836669.geojson
+++ b/data/144/483/666/9/1444836669.geojson
@@ -32,15 +32,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887577,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"df2b9683a394934e41b7034cddc13fce",
-    "wof:hierarchy":[],
+    "wof:geomhash":"331df5638643f5ebbd9c74965e92a2c5",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887577,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836669,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836669,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340267,
     "wof:name":"Ely",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887577,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -48,9 +67,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.250784117465384,
+    -3.25078411746538,
     51.47888707370208,
-    -3.250784117465384,
+    -3.25078411746538,
     51.47888707370208
 ],
   "geometry": {"coordinates":[-3.25078411746538,51.47888707370208],"type":"Point"}

--- a/data/144/483/668/3/1444836683.geojson
+++ b/data/144/483/668/3/1444836683.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836683,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.206152137,51.4830920538,-3.206152137,51.4830920538",
+    "geom:latitude":51.483092,
+    "geom:longitude":-3.206152,
+    "iso:country":"GB",
+    "lbl:latitude":51.483092,
+    "lbl:longitude":-3.206152,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Treganna"
+    ],
+    "name:eng_x_preferred":[
+        "Canton"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"94f4db3e24d82dc09374865c9375172c",
+    "wof:hierarchy":[],
+    "wof:id":1444836683,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Canton",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.20615213700087,
+    51.48309205381424,
+    -3.20615213700087,
+    51.48309205381424
+],
+  "geometry": {"coordinates":[-3.20615213700087,51.48309205381424],"type":"Point"}
+}

--- a/data/144/483/668/3/1444836683.geojson
+++ b/data/144/483/668/3/1444836683.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887569,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
     "wof:geomhash":"94f4db3e24d82dc09374865c9375172c",
-    "wof:hierarchy":[],
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887569,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836683,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836683,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340267,
     "wof:name":"Canton",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887569,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],

--- a/data/144/483/669/3/1444836693.geojson
+++ b/data/144/483/669/3/1444836693.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444836693,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.1893293136,51.4786019761,-3.1893293136,51.4786019761",
+    "geom:latitude":51.478602,
+    "geom:longitude":-3.189329,
+    "iso:country":"GB",
+    "lbl:latitude":51.478602,
+    "lbl:longitude":-3.189329,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Riverside"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"a8363e27754a9671bd70e1fb7279e57e",
+    "wof:hierarchy":[],
+    "wof:id":1444836693,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Riverside",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.189329313595014,
+    51.478601976089664,
+    -3.189329313595014,
+    51.478601976089664
+],
+  "geometry": {"coordinates":[-3.18932931359501,51.47860197608966],"type":"Point"}
+}

--- a/data/144/483/669/3/1444836693.geojson
+++ b/data/144/483/669/3/1444836693.geojson
@@ -26,15 +26,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887619,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"a8363e27754a9671bd70e1fb7279e57e",
-    "wof:hierarchy":[],
+    "wof:geomhash":"f7bebc826745ebd4b2e678674cc811a0",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887619,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836693,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836693,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340270,
     "wof:name":"Riverside",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887619,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +61,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.189329313595014,
-    51.478601976089664,
-    -3.189329313595014,
-    51.478601976089664
+    -3.18932931359501,
+    51.47860197608966,
+    -3.18932931359501,
+    51.47860197608966
 ],
   "geometry": {"coordinates":[-3.18932931359501,51.47860197608966],"type":"Point"}
 }

--- a/data/144/483/670/3/1444836703.geojson
+++ b/data/144/483/670/3/1444836703.geojson
@@ -26,15 +26,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887571,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"e1e667f0f2885b129ad48f145499c447",
-    "wof:hierarchy":[],
+    "wof:geomhash":"b1fc22c2d5fc60bc49aaa2e1495afa58",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887571,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836703,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836703,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340271,
     "wof:name":"Cathays Park",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887571,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.180631799453211,
+    -3.18063179945321,
     51.48622772347266,
-    -3.180631799453211,
+    -3.18063179945321,
     51.48622772347266
 ],
   "geometry": {"coordinates":[-3.18063179945321,51.48622772347266],"type":"Point"}

--- a/data/144/483/670/3/1444836703.geojson
+++ b/data/144/483/670/3/1444836703.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444836703,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.18063179945,51.4862277235,-3.18063179945,51.4862277235",
+    "geom:latitude":51.486228,
+    "geom:longitude":-3.180632,
+    "iso:country":"GB",
+    "lbl:latitude":51.486228,
+    "lbl:longitude":-3.180632,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Cathays Park"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"e1e667f0f2885b129ad48f145499c447",
+    "wof:hierarchy":[],
+    "wof:id":1444836703,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Cathays Park",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.180631799453211,
+    51.48622772347266,
+    -3.180631799453211,
+    51.48622772347266
+],
+  "geometry": {"coordinates":[-3.18063179945321,51.48622772347266],"type":"Point"}
+}

--- a/data/144/483/671/5/1444836715.geojson
+++ b/data/144/483/671/5/1444836715.geojson
@@ -26,15 +26,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887573,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"0ca4f02c2106675cf20d5d612e3b17e9",
-    "wof:hierarchy":[],
+    "wof:geomhash":"02f79b7d823e9f41afbda7016c75498f",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887573,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836715,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836715,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340272,
     "wof:name":"Cathays",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887573,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,10 +61,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.182462855062012,
-    51.494564698089086,
-    -3.182462855062012,
-    51.494564698089086
+    -3.18246285506201,
+    51.49456469808909,
+    -3.18246285506201,
+    51.49456469808909
 ],
   "geometry": {"coordinates":[-3.18246285506201,51.49456469808909],"type":"Point"}
 }

--- a/data/144/483/671/5/1444836715.geojson
+++ b/data/144/483/671/5/1444836715.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444836715,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.18246285506,51.4945646981,-3.18246285506,51.4945646981",
+    "geom:latitude":51.494565,
+    "geom:longitude":-3.182463,
+    "iso:country":"GB",
+    "lbl:latitude":51.494565,
+    "lbl:longitude":-3.182463,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Cathays"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"0ca4f02c2106675cf20d5d612e3b17e9",
+    "wof:hierarchy":[],
+    "wof:id":1444836715,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Cathays",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.182462855062012,
+    51.494564698089086,
+    -3.182462855062012,
+    51.494564698089086
+],
+  "geometry": {"coordinates":[-3.18246285506201,51.49456469808909],"type":"Point"}
+}

--- a/data/144/483/672/7/1444836727.geojson
+++ b/data/144/483/672/7/1444836727.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836727,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.19562356725,51.5006205184,-3.19562356725,51.5006205184",
+    "geom:latitude":51.500621,
+    "geom:longitude":-3.195624,
+    "iso:country":"GB",
+    "lbl:latitude":51.50062,
+    "lbl:longitude":-3.195623,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":15.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Gabalfa"
+    ],
+    "name:eng_x_preferred":[
+        "Gabalfa"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"d606236f209b63a4f75bbf440b1e11a7",
+    "wof:hierarchy":[],
+    "wof:id":1444836727,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Gabalfa",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.195623567250266,
+    51.50062051843512,
+    -3.195623567250266,
+    51.50062051843512
+],
+  "geometry": {"coordinates":[-3.19562356725027,51.50062051843512],"type":"Point"}
+}

--- a/data/144/483/672/7/1444836727.geojson
+++ b/data/144/483/672/7/1444836727.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887583,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"d606236f209b63a4f75bbf440b1e11a7",
-    "wof:hierarchy":[],
+    "wof:geomhash":"1e4af4421a4f0b608d2512eba61981cc",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887583,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836727,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836727,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340272,
     "wof:name":"Gabalfa",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887583,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.195623567250266,
+    -3.19562356725027,
     51.50062051843512,
-    -3.195623567250266,
+    -3.19562356725027,
     51.50062051843512
 ],
   "geometry": {"coordinates":[-3.19562356725027,51.50062051843512],"type":"Point"}

--- a/data/144/483/673/7/1444836737.geojson
+++ b/data/144/483/673/7/1444836737.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836737,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.14584174289,51.4818804826,-3.14584174289,51.4818804826",
+    "geom:latitude":51.48188,
+    "geom:longitude":-3.145842,
+    "iso:country":"GB",
+    "lbl:latitude":51.48188,
+    "lbl:longitude":-3.145842,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Y Sblot"
+    ],
+    "name:eng_x_preferred":[
+        "Splott"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"bcd3004a9c551a46c3d36ba111ca65c2",
+    "wof:hierarchy":[],
+    "wof:id":1444836737,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Splott",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.145841742885999,
+    51.48188048257534,
+    -3.145841742885999,
+    51.48188048257534
+],
+  "geometry": {"coordinates":[-3.145841742886,51.48188048257534],"type":"Point"}
+}

--- a/data/144/483/673/7/1444836737.geojson
+++ b/data/144/483/673/7/1444836737.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887625,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"bcd3004a9c551a46c3d36ba111ca65c2",
-    "wof:hierarchy":[],
+    "wof:geomhash":"6f0e4d1c612d36d092779f69c31622fb",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887625,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836737,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836737,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340275,
     "wof:name":"Splott",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887625,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,9 +64,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.145841742885999,
+    -3.145841742886,
     51.48188048257534,
-    -3.145841742885999,
+    -3.145841742886,
     51.48188048257534
 ],
   "geometry": {"coordinates":[-3.145841742886,51.48188048257534],"type":"Point"}

--- a/data/144/483/674/3/1444836743.geojson
+++ b/data/144/483/674/3/1444836743.geojson
@@ -32,15 +32,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887563,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"adc333af0c4860286306f007a8702841",
-    "wof:hierarchy":[],
+    "wof:geomhash":"2acd229349dacd002f99be99daf5b745",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887563,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836743,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836743,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340276,
     "wof:name":"Adamsdown",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887563,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -48,9 +67,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.164953385802856,
+    -3.16495338580286,
     51.48052635039006,
-    -3.164953385802856,
+    -3.16495338580286,
     51.48052635039006
 ],
   "geometry": {"coordinates":[-3.16495338580286,51.48052635039006],"type":"Point"}

--- a/data/144/483/674/3/1444836743.geojson
+++ b/data/144/483/674/3/1444836743.geojson
@@ -1,0 +1,57 @@
+{
+  "id": 1444836743,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.1649533858,51.4805263504,-3.1649533858,51.4805263504",
+    "geom:latitude":51.480526,
+    "geom:longitude":-3.164953,
+    "iso:country":"GB",
+    "lbl:latitude":51.480526,
+    "lbl:longitude":-3.164953,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Waunadda"
+    ],
+    "name:cym_x_variant":[
+        "Y Sblot Uchaf"
+    ],
+    "name:eng_x_preferred":[
+        "Adamsdown"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"adc333af0c4860286306f007a8702841",
+    "wof:hierarchy":[],
+    "wof:id":1444836743,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Adamsdown",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.164953385802856,
+    51.48052635039006,
+    -3.164953385802856,
+    51.48052635039006
+],
+  "geometry": {"coordinates":[-3.16495338580286,51.48052635039006],"type":"Point"}
+}

--- a/data/144/483/676/1/1444836761.geojson
+++ b/data/144/483/676/1/1444836761.geojson
@@ -26,15 +26,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887585,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"2f671d797644e4cf556ad60d5a36d5a2",
-    "wof:hierarchy":[],
+    "wof:geomhash":"e582287490650bf2b1617623d21e83a2",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887585,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836761,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836761,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340277,
     "wof:name":"Grangetown",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887585,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.185438320426313,
+    -3.18543832042631,
     51.46484389881503,
-    -3.185438320426313,
+    -3.18543832042631,
     51.46484389881503
 ],
   "geometry": {"coordinates":[-3.18543832042631,51.46484389881503],"type":"Point"}

--- a/data/144/483/676/1/1444836761.geojson
+++ b/data/144/483/676/1/1444836761.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444836761,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.18543832043,51.4648438988,-3.18543832043,51.4648438988",
+    "geom:latitude":51.464844,
+    "geom:longitude":-3.185438,
+    "iso:country":"GB",
+    "lbl:latitude":51.464844,
+    "lbl:longitude":-3.185438,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":13.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "Grangetown"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"2f671d797644e4cf556ad60d5a36d5a2",
+    "wof:hierarchy":[],
+    "wof:id":1444836761,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Grangetown",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.185438320426313,
+    51.46484389881503,
+    -3.185438320426313,
+    51.46484389881503
+],
+  "geometry": {"coordinates":[-3.18543832042631,51.46484389881503],"type":"Point"}
+}

--- a/data/144/483/677/3/1444836773.geojson
+++ b/data/144/483/677/3/1444836773.geojson
@@ -1,0 +1,51 @@
+{
+  "id": 1444836773,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.15122046874,51.4740401719,-3.15122046874,51.4740401719",
+    "geom:latitude":51.47404,
+    "geom:longitude":-3.15122,
+    "iso:country":"GB",
+    "lbl:latitude":51.47404,
+    "lbl:longitude":-3.15122,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":0,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:eng_x_preferred":[
+        "East Moors"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"1326c99417f787cea2f43bd15f8c5503",
+    "wof:hierarchy":[],
+    "wof:id":1444836773,
+    "wof:lastmodified":1566334998,
+    "wof:name":"East Moors",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.151220468736852,
+    51.4740401719242,
+    -3.151220468736852,
+    51.4740401719242
+],
+  "geometry": {"coordinates":[-3.15122046873685,51.4740401719242],"type":"Point"}
+}

--- a/data/144/483/677/3/1444836773.geojson
+++ b/data/144/483/677/3/1444836773.geojson
@@ -26,15 +26,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887625,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"1326c99417f787cea2f43bd15f8c5503",
-    "wof:hierarchy":[],
+    "wof:geomhash":"02905b64bad1a86a602beac3b1105077",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887625,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836773,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836773,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340277,
     "wof:name":"East Moors",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887625,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -42,9 +61,9 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.151220468736852,
+    -3.15122046873685,
     51.4740401719242,
-    -3.151220468736852,
+    -3.15122046873685,
     51.4740401719242
 ],
   "geometry": {"coordinates":[-3.15122046873685,51.4740401719242],"type":"Point"}

--- a/data/144/483/678/3/1444836783.geojson
+++ b/data/144/483/678/3/1444836783.geojson
@@ -1,0 +1,54 @@
+{
+  "id": 1444836783,
+  "type": "Feature",
+  "properties": {
+    "edtf:cessation":"uuuu",
+    "edtf:inception":"uuuu",
+    "geom:area":0.0,
+    "geom:area_square_m":0.0,
+    "geom:bbox":"-3.17857186189,51.4815241421,-3.17857186189,51.4815241421",
+    "geom:latitude":51.481524,
+    "geom:longitude":-3.178572,
+    "iso:country":"GB",
+    "lbl:latitude":51.481524,
+    "lbl:longitude":-3.178572,
+    "mz:hierarchy_label":1,
+    "mz:is_current":1,
+    "mz:is_funky":0,
+    "mz:is_hard_boundary":0,
+    "mz:is_landuse_aoi":0,
+    "mz:is_official":1,
+    "mz:max_zoom":18.0,
+    "mz:min_zoom":14.0,
+    "mz:tier_metro":30,
+    "name:cym_x_preferred":[
+        "Castle"
+    ],
+    "name:eng_x_preferred":[
+        "Castle"
+    ],
+    "src:geom":"whosonfirst",
+    "src:lbl_centroid":"whosonfirst",
+    "wof:belongsto":[],
+    "wof:breaches":[],
+    "wof:country":"GB",
+    "wof:geomhash":"ad18a8b0fac2435b3c1d6db7018922f5",
+    "wof:hierarchy":[],
+    "wof:id":1444836783,
+    "wof:lastmodified":1566334998,
+    "wof:name":"Castle",
+    "wof:parent_id":-1,
+    "wof:placetype":"neighbourhood",
+    "wof:repo":"whosonfirst-data-admin-gb",
+    "wof:superseded_by":[],
+    "wof:supersedes":[],
+    "wof:tags":[]
+},
+  "bbox": [
+    -3.178571861893312,
+    51.481524142135584,
+    -3.178571861893312,
+    51.481524142135584
+],
+  "geometry": {"coordinates":[-3.17857186189331,51.48152414213558],"type":"Point"}
+}

--- a/data/144/483/678/3/1444836783.geojson
+++ b/data/144/483/678/3/1444836783.geojson
@@ -29,15 +29,34 @@
     ],
     "src:geom":"whosonfirst",
     "src:lbl_centroid":"whosonfirst",
-    "wof:belongsto":[],
+    "wof:belongsto":[
+        1360698627,
+        102191581,
+        85633159,
+        404227475,
+        101750397,
+        1360887571,
+        1360699107
+    ],
     "wof:breaches":[],
     "wof:country":"GB",
-    "wof:geomhash":"ad18a8b0fac2435b3c1d6db7018922f5",
-    "wof:hierarchy":[],
+    "wof:geomhash":"33d17c59d7e1102396837a8a21886476",
+    "wof:hierarchy":[
+        {
+            "borough_id":1360887571,
+            "continent_id":102191581,
+            "country_id":85633159,
+            "county_id":1360699107,
+            "locality_id":101750397,
+            "macroregion_id":404227475,
+            "neighbourhood_id":1444836783,
+            "region_id":1360698627
+        }
+    ],
     "wof:id":1444836783,
-    "wof:lastmodified":1566334998,
+    "wof:lastmodified":1566340280,
     "wof:name":"Castle",
-    "wof:parent_id":-1,
+    "wof:parent_id":1360887571,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
@@ -45,10 +64,10 @@
     "wof:tags":[]
 },
   "bbox": [
-    -3.178571861893312,
-    51.481524142135584,
-    -3.178571861893312,
-    51.481524142135584
+    -3.17857186189331,
+    51.48152414213558,
+    -3.17857186189331,
+    51.48152414213558
 ],
   "geometry": {"coordinates":[-3.17857186189331,51.48152414213558],"type":"Point"}
 }


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1695.

This PR contains new neighbourhood records from Nat's neighbourhood import file. 