### PR TITLE
Fixes at the locality level - GB

### DIFF
--- a/data/112/589/333/7/1125893337.geojson
+++ b/data/112/589/333/7/1125893337.geojson
@@ -3,6 +3,7 @@
   "type": "Feature",
   "properties": {
     "edtf:cessation":"uuuu",
+    "edtf:deprecated":"2019-09-10",
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
@@ -19,7 +20,7 @@
     "lbl:max_zoom":14.0,
     "lbl:min_zoom":9.5,
     "mz:hierarchy_label":1,
-    "mz:is_current":1,
+    "mz:is_current":0,
     "mz:min_zoom":8.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "name:ara_x_preferred":[
@@ -215,14 +216,16 @@
         }
     ],
     "wof:id":1125893337,
-    "wof:lastmodified":1566634941,
+    "wof:lastmodified":1568137241,
     "wof:name":"Paisley",
     "wof:parent_id":404432463,
     "wof:placetype":"locality",
     "wof:population":76220,
     "wof:population_rank":8,
     "wof:repo":"whosonfirst-data-admin-gb",
-    "wof:superseded_by":[],
+    "wof:superseded_by":[
+        1125903301
+    ],
     "wof:supersedes":[],
     "wof:tags":[]
 },

--- a/data/112/590/330/1/1125903301.geojson
+++ b/data/112/590/330/1/1125903301.geojson
@@ -222,13 +222,15 @@
         }
     ],
     "wof:id":1125903301,
-    "wof:lastmodified":1566635289,
+    "wof:lastmodified":1568137245,
     "wof:name":"Paisley",
     "wof:parent_id":404432463,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-gb",
     "wof:superseded_by":[],
-    "wof:supersedes":[],
+    "wof:supersedes":[
+        1125893337
+    ],
     "wof:tags":[]
 },
   "bbox": [

--- a/data/112/605/110/3/1126051103.geojson
+++ b/data/112/605/110/3/1126051103.geojson
@@ -20,43 +20,10 @@
     "mz:min_zoom":12.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "name:eng_x_preferred":[
+        "Woolston"
+    ],
+    "name:eng_x_variant":[
         "Woolton"
-    ],
-    "name:fas_x_preferred":[
-        "\u0648\u0648\u0644\u062a\u0648\u0646"
-    ],
-    "name:fra_x_preferred":[
-        "Woolton"
-    ],
-    "name:gle_x_preferred":[
-        "Woolton"
-    ],
-    "name:glv_x_preferred":[
-        "Woolton"
-    ],
-    "name:heb_x_preferred":[
-        "\u05d5\u05d5\u05dc\u05d8\u05d5\u05df"
-    ],
-    "name:ita_x_preferred":[
-        "Woolton"
-    ],
-    "name:jpn_x_preferred":[
-        "\u30a6\u30fc\u30eb\u30c8\u30f3"
-    ],
-    "name:nld_x_preferred":[
-        "Woolton"
-    ],
-    "name:pol_x_preferred":[
-        "Woolton"
-    ],
-    "name:slv_x_preferred":[
-        "Woolton"
-    ],
-    "name:spa_x_preferred":[
-        "Woolton"
-    ],
-    "name:zho_x_preferred":[
-        "\u80e1\u723e\u9813"
     ],
     "qs_pg:aaroncc":"GB",
     "qs_pg:gn_country":null,
@@ -116,7 +83,7 @@
         }
     ],
     "wof:id":1126051103,
-    "wof:lastmodified":1566634441,
+    "wof:lastmodified":1568136442,
     "wof:name":"Woolston",
     "wof:parent_id":404430553,
     "wof:placetype":"locality",

--- a/data/126/031/564/5/1260315645.geojson
+++ b/data/126/031/564/5/1260315645.geojson
@@ -30,43 +30,10 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
-    "name:ceb_x_preferred":[
-        "Claudy"
+    "name:eng_x_preferred":[
+        "Clady"
     ],
-    "name:deu_x_preferred":[
-        "Claudy"
-    ],
-    "name:eus_x_preferred":[
-        "Claudy"
-    ],
-    "name:fas_x_preferred":[
-        "\u06a9\u0644\u0627\u0648\u062f\u06cc"
-    ],
-    "name:gla_x_preferred":[
-        "Cl\u00f3idigh"
-    ],
-    "name:gle_x_preferred":[
-        "Cl\u00f3idigh"
-    ],
-    "name:ita_x_preferred":[
-        "Claudy"
-    ],
-    "name:msa_x_preferred":[
-        "Claudy"
-    ],
-    "name:nld_x_preferred":[
-        "Claudy"
-    ],
-    "name:pli_x_preferred":[
-        "\u0915\u094d\u0932\u094c\u0926\u094d\u092f"
-    ],
-    "name:sco_x_preferred":[
-        "Claudy"
-    ],
-    "name:spa_x_preferred":[
-        "Claudy"
-    ],
-    "name:swe_x_preferred":[
+    "name:eng_x_variant":[
         "Claudy"
     ],
     "src:geom":"geonames",
@@ -92,8 +59,8 @@
         }
     ],
     "wof:id":1260315645,
-    "wof:lastmodified":1566628171,
-    "wof:name":"Claudy",
+    "wof:lastmodified":1568136434,
+    "wof:name":"Clady",
     "wof:parent_id":85684409,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-gb",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1700
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1684

- Supersedes one duplicate record for Paisley, UK into another
- Corrects names of two localities in the UK, removing most name translations (they reference an incorrect name)