### PR TITLE
Fix names in two records

### DIFF
--- a/data/101/873/667/101873667.geojson
+++ b/data/101/873/667/101873667.geojson
@@ -17,17 +17,13 @@
     "lbl:min_zoom":13.5,
     "mps:latitude":57.479549,
     "mps:longitude":-4.237208,
-    "mz:categories":[],
     "mz:hierarchy_label":1,
-    "mz:hours":[],
     "mz:is_current":1,
     "mz:min_zoom":6.1,
     "name:afr_x_preferred":[
         "Inverness"
     ],
-    "name:ara_x_colloquial":[],
-    "name:ara_x_preferred":[],
-    "name:ara_x_variant":[
+    "name:ara_x_preferred":[
         "\u0625\u0646\u0641\u0631\u0646\u064a\u0633"
     ],
     "name:ast_x_preferred":[
@@ -39,9 +35,7 @@
     "name:aze_x_preferred":[
         "\u0130nverness"
     ],
-    "name:ben_x_colloquial":[],
-    "name:ben_x_preferred":[],
-    "name:ben_x_variant":[
+    "name:ben_x_preferred":[
         "\u0987\u09ad\u09be\u09b0\u09a8\u09c7\u09b8"
     ],
     "name:bre_x_preferred":[
@@ -71,7 +65,6 @@
     "name:ell_x_preferred":[
         "\u0399\u03bd\u03b2\u03b5\u03c1\u03bd\u03ad\u03c2"
     ],
-    "name:eng_x_colloquial":[],
     "name:eng_x_preferred":[
         "Inverness"
     ],
@@ -96,14 +89,6 @@
     "name:fra_x_preferred":[
         "Inverness"
     ],
-    "name:fre_x_colloquial":[],
-    "name:fre_x_variant":[
-        "Inverness"
-    ],
-    "name:ger_x_colloquial":[],
-    "name:ger_x_variant":[
-        "Inverness"
-    ],
     "name:gla_x_preferred":[
         "Inbhir Nis"
     ],
@@ -116,8 +101,7 @@
     "name:glv_x_preferred":[
         "Inbhir Nis"
     ],
-    "name:gre_x_colloquial":[],
-    "name:gre_x_variant":[
+    "name:gre_x_preferred":[
         "\u0399\u03bd\u03b2\u03b5\u03c1\u03bd\u03ad\u03c2"
     ],
     "name:guj_x_preferred":[
@@ -126,9 +110,7 @@
     "name:heb_x_preferred":[
         "\u05d0\u05d9\u05e0\u05d5\u05d5\u05e8\u05e0\u05e1"
     ],
-    "name:hin_x_colloquial":[],
-    "name:hin_x_preferred":[],
-    "name:hin_x_variant":[
+    "name:hin_x_preferred":[
         "\u0907\u0928\u0935\u0930\u094d\u0928\u0947\u0938"
     ],
     "name:hun_x_preferred":[
@@ -143,14 +125,9 @@
     "name:isl_x_preferred":[
         "Inverness"
     ],
-    "name:ita_x_colloquial":[],
-    "name:ita_x_preferred":[],
-    "name:ita_x_variant":[
+    "name:ita_x_preferred":[
         "Inverness"
     ],
-    "name:jap_x_colloquial":[],
-    "name:jap_x_preferred":[],
-    "name:jap_x_variant":[],
     "name:jpn_x_preferred":[
         "\u30a4\u30f3\u30f4\u30a1\u30cd\u30b9"
     ],
@@ -160,9 +137,7 @@
     "name:kaz_x_preferred":[
         "\u0418\u043d\u0432\u0435\u0440\u043d\u0435\u0441\u0441"
     ],
-    "name:kor_x_colloquial":[],
-    "name:kor_x_preferred":[],
-    "name:kor_x_variant":[
+    "name:kor_x_preferred":[
         "\uc778\ubc84\ub124\uc2a4"
     ],
     "name:lav_x_preferred":[
@@ -207,9 +182,7 @@
     "name:pol_x_preferred":[
         "Inverness"
     ],
-    "name:por_x_colloquial":[],
-    "name:por_x_preferred":[],
-    "name:por_x_variant":[
+    "name:por_x_preferred":[
         "Inverness"
     ],
     "name:que_x_preferred":[
@@ -218,9 +191,7 @@
     "name:ron_x_preferred":[
         "Inverness"
     ],
-    "name:rus_x_colloquial":[],
-    "name:rus_x_preferred":[],
-    "name:rus_x_variant":[
+    "name:rus_x_preferred":[
         "\u0418\u043d\u0432\u0435\u0440\u043d\u0435\u0441\u0441"
     ],
     "name:scn_x_preferred":[
@@ -241,9 +212,7 @@
     "name:slv_x_preferred":[
         "Inverness"
     ],
-    "name:spa_x_colloquial":[],
-    "name:spa_x_preferred":[],
-    "name:spa_x_variant":[
+    "name:spa_x_preferred":[
         "Inverness"
     ],
     "name:srp_x_preferred":[
@@ -267,15 +236,12 @@
     "name:tha_x_preferred":[
         "\u0e2d\u0e34\u0e19\u0e40\u0e27\u0e2d\u0e23\u0e4c\u0e40\u0e19\u0e2a\u0e2a\u0e4c"
     ],
-    "name:tur_x_colloquial":[],
-    "name:tur_x_preferred":[],
-    "name:tur_x_variant":[
+    "name:tur_x_preferred":[
         "Inverness"
     ],
     "name:ukr_x_preferred":[
         "\u0406\u043d\u0432\u0435\u0440\u043d\u0435\u0441\u0441"
     ],
-    "name:und_x_colloquial":[],
     "name:und_x_variant":[
         "\u0399\u03bd\u03b2\u03b5\u03c1\u03bd\u03b5\u03c3"
     ],
@@ -285,9 +251,7 @@
     "name:vec_x_preferred":[
         "Inverness"
     ],
-    "name:vie_x_colloquial":[],
-    "name:vie_x_preferred":[],
-    "name:vie_x_variant":[
+    "name:vie_x_preferred":[
         "Inverness"
     ],
     "name:vol_x_preferred":[
@@ -305,9 +269,7 @@
     "name:zea_x_preferred":[
         "Inverness"
     ],
-    "name:zho_x_colloquial":[],
-    "name:zho_x_preferred":[],
-    "name:zho_x_variant":[
+    "name:zho_x_preferred":[
         "\u5370\u5a01\u5167\u65af"
     ],
     "ne:ADM0CAP":0,
@@ -452,7 +414,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566630775,
+    "wof:lastmodified":1568240234,
     "wof:name":"Inverness",
     "wof:parent_id":404436073,
     "wof:placetype":"locality",

--- a/data/136/069/900/3/1360699003.geojson
+++ b/data/136/069/900/3/1360699003.geojson
@@ -19,18 +19,14 @@
     "lbl:min_zoom":8.0,
     "mps:latitude":56.281067,
     "mps:longitude":-4.436736,
-    "mz:categories":[],
     "mz:hierarchy_label":1,
-    "mz:hours":[],
     "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":9.0,
     "name:ang_x_preferred":[
         "Striuelin"
     ],
-    "name:ara_x_colloquial":[],
-    "name:ara_x_preferred":[],
-    "name:ara_x_variant":[
+    "name:ara_x_preferred":[
         "\u0625\u0633\u062a\u064a\u0631\u0644\u064a\u0646\u063a"
     ],
     "name:ast_x_preferred":[
@@ -42,9 +38,6 @@
     "name:aze_x_preferred":[
         "Stirlinq"
     ],
-    "name:ben_x_colloquial":[],
-    "name:ben_x_preferred":[],
-    "name:ben_x_variant":[],
     "name:bre_x_preferred":[
         "Sruighlea"
     ],
@@ -63,12 +56,9 @@
     "name:dan_x_preferred":[
         "Stirling"
     ],
-    "name:deu_x_preferred":[],
     "name:deu_x_variant":[
         "Stirling"
     ],
-    "name:ell_x_preferred":[],
-    "name:eng_x_colloquial":[],
     "name:eng_x_preferred":[
         "Stirling"
     ],
@@ -92,14 +82,9 @@
     "name:fin_x_preferred":[
         "Stirling"
     ],
-    "name:fra_x_preferred":[],
-    "name:fra_x_variant":[
+    "name:fra_x_preferred":[
         "Stirling"
     ],
-    "name:fre_x_colloquial":[],
-    "name:fre_x_variant":[],
-    "name:ger_x_colloquial":[],
-    "name:ger_x_variant":[],
     "name:gla_x_preferred":[
         "Sruighlea"
     ],
@@ -109,11 +94,7 @@
     "name:glg_x_preferred":[
         "Stirling"
     ],
-    "name:gre_x_colloquial":[],
-    "name:gre_x_variant":[],
-    "name:hin_x_colloquial":[],
-    "name:hin_x_preferred":[],
-    "name:hin_x_variant":[
+    "name:hin_x_preferred":[
         "\u0938\u094d\u091f\u0930\u094d\u0932\u093f\u0902\u0917"
     ],
     "name:hun_x_preferred":[
@@ -131,23 +112,16 @@
     "name:isl_x_preferred":[
         "Stirling"
     ],
-    "name:ita_x_colloquial":[],
-    "name:ita_x_preferred":[],
-    "name:ita_x_variant":[
+    "name:ita_x_preferred":[
         "Stirling"
     ],
-    "name:jap_x_colloquial":[],
-    "name:jap_x_preferred":[],
-    "name:jap_x_variant":[],
     "name:jpn_x_preferred":[
         "\u30b9\u30bf\u30fc\u30ea\u30f3\u30b0"
     ],
     "name:kaz_x_preferred":[
         "\u0421\u0442\u0435\u0440\u043b\u0438\u043d\u0433"
     ],
-    "name:kor_x_colloquial":[],
-    "name:kor_x_preferred":[],
-    "name:kor_x_variant":[
+    "name:kor_x_preferred":[
         "\uc2a4\ud138\ub9c1"
     ],
     "name:lat_x_preferred":[
@@ -177,25 +151,19 @@
     "name:pol_x_preferred":[
         "Stirling"
     ],
-    "name:por_x_colloquial":[],
-    "name:por_x_preferred":[],
-    "name:por_x_variant":[
+    "name:por_x_preferred":[
         "Stirling"
     ],
     "name:ron_x_preferred":[
         "Stirling"
     ],
-    "name:rus_x_colloquial":[],
-    "name:rus_x_preferred":[],
-    "name:rus_x_variant":[
+    "name:rus_x_preferred":[
         "\u0421\u0442\u0435\u0440\u043b\u0438\u043d\u0433"
     ],
     "name:sco_x_preferred":[
         "Stirlin"
     ],
-    "name:spa_x_colloquial":[],
-    "name:spa_x_preferred":[],
-    "name:spa_x_variant":[
+    "name:spa_x_preferred":[
         "Stirling"
     ],
     "name:swe_x_preferred":[
@@ -207,9 +175,7 @@
     "name:tha_x_preferred":[
         "\u0e2a\u0e40\u0e15\u0e2d\u0e23\u0e4c\u0e25\u0e34\u0e07"
     ],
-    "name:tur_x_colloquial":[],
-    "name:tur_x_preferred":[],
-    "name:tur_x_variant":[
+    "name:tur_x_preferred":[
         "Stirling"
     ],
     "name:ukr_x_preferred":[
@@ -218,9 +184,6 @@
     "name:urd_x_preferred":[
         "\u0633\u0679\u0631\u0644\u0646\u06af"
     ],
-    "name:vie_x_colloquial":[],
-    "name:vie_x_preferred":[],
-    "name:vie_x_variant":[],
     "name:vol_x_preferred":[
         "Stirling"
     ],
@@ -230,9 +193,7 @@
     "name:wuu_x_preferred":[
         "\u65af\u7279\u7075"
     ],
-    "name:zho_x_colloquial":[],
-    "name:zho_x_preferred":[],
-    "name:zho_x_variant":[
+    "name:zho_x_preferred":[
         "\u53f2\u7279\u9748"
     ],
     "ne:abbrev":"",
@@ -363,7 +324,7 @@
         "gla",
         "gle"
     ],
-    "wof:lastmodified":1566630405,
+    "wof:lastmodified":1568240242,
     "wof:name":"Stirling",
     "wof:parent_id":1360698655,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes the last portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1709

Removes bunk and empty name properties in two records in GB. It looks like these odd name properties are a relic of some old Boundary Issues edits.

No PIP required, can merge once approved.