### PR TITLE
Standardize on unknown source

### DIFF
--- a/data/102/556/945/102556945.geojson
+++ b/data/102/556/945/102556945.geojson
@@ -21,7 +21,7 @@
         "CLF",
         "PACL"
     ],
-    "src:geom":"missing",
+    "src:geom":"unknown",
     "src:geom_alt":[],
     "woe:hierarchy":{
         "country_id":23424975,
@@ -41,7 +41,7 @@
         "icao:code":"PACL"
     },
     "wof:country":"GB",
-    "wof:geomhash":"83e15ca7275cf883624bb6fa862e15fa",
+    "wof:geomhash":"a4bb03cc4c85d9637292977b5e054a0f",
     "wof:hierarchy":[
         {
             "campus_id":102556945,
@@ -50,7 +50,7 @@
         }
     ],
     "wof:id":102556945,
-    "wof:lastmodified":1566627415,
+    "wof:lastmodified":1589218812,
     "wof:name":"Coltishall Airport",
     "wof:parent_id":85683947,
     "wof:placetype":"campus",
@@ -67,5 +67,5 @@
     0.0,
     0.0
 ],
-  "geometry": {"coordinates":[0,0],"type":"Point"}
+  "geometry": {"coordinates":[0.0,0.0],"type":"Point"}
 }


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst/whosonfirst-sources/issues/112.

Swaps any "missing" values in `src:geom` properties to "unknown". I also checked values in `src:geom_alt` and `wof:geom_alt` properties, but there were no cases.

No PIP required, can merge once approved.