### PR TITLE
Update Falkland Islands names

### DIFF
--- a/data/856/322/11/85632211.geojson
+++ b/data/856/322/11/85632211.geojson
@@ -178,14 +178,14 @@
         "Falkland Islands"
     ],
     "name:eng_x_preferred":[
-        "Falkland Islands (Islas Malvinas)"
+        "Falkland Islands"
     ],
     "name:eng_x_unknown":[
         "FK",
         "FLK"
     ],
     "name:eng_x_variant":[
-        "Falkland Islands",
+        "Falkland Islands (Islas Malvinas)",
         "Colony of the Falkland Islands",
         "Falkland Islander",
         "Falkland Isles",
@@ -940,7 +940,7 @@
         }
     ],
     "wof:id":85632211,
-    "wof:lastmodified":1617827328,
+    "wof:lastmodified":1652226672,
     "wof:name":"Falkland Islands",
     "wof:parent_id":136253055,
     "wof:placetype":"dependency",

--- a/data/856/322/11/85632211.geojson
+++ b/data/856/322/11/85632211.geojson
@@ -14,6 +14,9 @@
     "itu:country_code":[
         "500"
     ],
+    "label:eng_x_preferred_longname":[
+        "Falkland Islands"
+    ],
     "label:eng_x_preferred_shortcode":[
         "FK"
     ],
@@ -178,14 +181,14 @@
         "Falkland Islands"
     ],
     "name:eng_x_preferred":[
-        "Falkland Islands"
+        "Falkland Islands (Islas Malvinas)"
     ],
     "name:eng_x_unknown":[
         "FK",
         "FLK"
     ],
     "name:eng_x_variant":[
-        "Falkland Islands (Islas Malvinas)",
+        "Falkland Islands",
         "Colony of the Falkland Islands",
         "Falkland Islander",
         "Falkland Isles",
@@ -940,7 +943,7 @@
         }
     ],
     "wof:id":85632211,
-    "wof:lastmodified":1652226672,
+    "wof:lastmodified":1652284606,
     "wof:name":"Falkland Islands",
     "wof:parent_id":136253055,
     "wof:placetype":"dependency",


### PR DESCRIPTION
This PR updates the English preferred and variant names for the Falkland Islands dependency/region record.