### PR TITLE
fix: use empty object for concordances

### DIFF
--- a/data/188/076/198/5/1880761985.geojson
+++ b/data/188/076/198/5/1880761985.geojson
@@ -88,7 +88,7 @@
         404227471
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"ebe1ad595472bb88967944cc7cbcf7cd",

--- a/data/188/076/198/7/1880761987.geojson
+++ b/data/188/076/198/7/1880761987.geojson
@@ -248,7 +248,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"3f312098fcfd3631367c7575a66d8709",

--- a/data/188/076/198/9/1880761989.geojson
+++ b/data/188/076/198/9/1880761989.geojson
@@ -245,7 +245,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"81271d97e6bb6e9b71b70273b2132154",

--- a/data/188/076/199/1/1880761991.geojson
+++ b/data/188/076/199/1/1880761991.geojson
@@ -40,7 +40,7 @@
         404227471
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"688a59fa6dda81b323f29d829d5b6bcf",

--- a/data/188/076/199/3/1880761993.geojson
+++ b/data/188/076/199/3/1880761993.geojson
@@ -263,7 +263,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"025a7b2f93607a8a3e71fb64a398a2a8",

--- a/data/188/076/199/7/1880761997.geojson
+++ b/data/188/076/199/7/1880761997.geojson
@@ -212,7 +212,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"0472020c9bf37015c582c4b6af3427b9",

--- a/data/188/076/199/9/1880761999.geojson
+++ b/data/188/076/199/9/1880761999.geojson
@@ -236,7 +236,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"3af8b9b57be1bf12149d1549fc15b460",

--- a/data/188/076/200/1/1880762001.geojson
+++ b/data/188/076/200/1/1880762001.geojson
@@ -248,7 +248,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"fe6232ed3e0ac49c398927a01a9df8cc",

--- a/data/188/076/200/3/1880762003.geojson
+++ b/data/188/076/200/3/1880762003.geojson
@@ -65,7 +65,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"bd362b705a6f0a3392f5c0f76c1dded4",

--- a/data/188/076/200/5/1880762005.geojson
+++ b/data/188/076/200/5/1880762005.geojson
@@ -248,7 +248,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"c583e16375d2db2bc219245fec9dfdd2",

--- a/data/188/076/200/7/1880762007.geojson
+++ b/data/188/076/200/7/1880762007.geojson
@@ -143,7 +143,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"a0889c3ff0a2384a40e7d4e5b4edaca1",

--- a/data/188/076/200/9/1880762009.geojson
+++ b/data/188/076/200/9/1880762009.geojson
@@ -95,7 +95,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"69289409383eab233f4cf3a4cb4e4d63",

--- a/data/188/076/201/1/1880762011.geojson
+++ b/data/188/076/201/1/1880762011.geojson
@@ -227,7 +227,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"1884830c3c525c1ff454b4c8a1a605bd",

--- a/data/188/076/201/5/1880762015.geojson
+++ b/data/188/076/201/5/1880762015.geojson
@@ -227,7 +227,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"3b462a0361ae50afdf1bcbf9c6122485",

--- a/data/188/076/201/7/1880762017.geojson
+++ b/data/188/076/201/7/1880762017.geojson
@@ -239,7 +239,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"f9fdebd5192779e40cf55dba9b7b2b01",

--- a/data/188/076/201/9/1880762019.geojson
+++ b/data/188/076/201/9/1880762019.geojson
@@ -230,7 +230,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"4ba4c115506e8f63f06e931783e640ac",

--- a/data/188/076/202/1/1880762021.geojson
+++ b/data/188/076/202/1/1880762021.geojson
@@ -92,7 +92,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"b327dae1701de95687a108a5cae62ff7",

--- a/data/188/076/202/3/1880762023.geojson
+++ b/data/188/076/202/3/1880762023.geojson
@@ -255,7 +255,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:controlled":[
         "wof:hierarchy",
         "wof:parent_id"

--- a/data/188/076/202/5/1880762025.geojson
+++ b/data/188/076/202/5/1880762025.geojson
@@ -251,7 +251,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"715aeb82a0c58ccab96624add9aa60db",

--- a/data/188/076/202/7/1880762027.geojson
+++ b/data/188/076/202/7/1880762027.geojson
@@ -42,7 +42,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"0e32c19388a6458021dc510d97c1fdd3",

--- a/data/188/076/202/9/1880762029.geojson
+++ b/data/188/076/202/9/1880762029.geojson
@@ -248,7 +248,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"dbbb0ac9a2ecd5005accced6f595a38b",

--- a/data/188/076/203/3/1880762033.geojson
+++ b/data/188/076/203/3/1880762033.geojson
@@ -248,7 +248,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"59dbbfd75c1e3ac76636042b60705588",

--- a/data/188/076/203/5/1880762035.geojson
+++ b/data/188/076/203/5/1880762035.geojson
@@ -236,7 +236,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"09459292193f5393b4aee93c689da68a",

--- a/data/188/076/203/7/1880762037.geojson
+++ b/data/188/076/203/7/1880762037.geojson
@@ -257,7 +257,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"8ccee211c90c79393becd2bb851ae399",

--- a/data/188/076/203/9/1880762039.geojson
+++ b/data/188/076/203/9/1880762039.geojson
@@ -146,7 +146,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"99ff813e7769282737ed0f5441dc4abe",

--- a/data/188/076/204/1/1880762041.geojson
+++ b/data/188/076/204/1/1880762041.geojson
@@ -47,7 +47,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"2f22180bd91c72de95ef5bfd8b00f4f6",

--- a/data/188/076/204/3/1880762043.geojson
+++ b/data/188/076/204/3/1880762043.geojson
@@ -164,7 +164,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"2aefd558af6a1045ee7d8af3325f65a4",

--- a/data/188/076/204/5/1880762045.geojson
+++ b/data/188/076/204/5/1880762045.geojson
@@ -41,7 +41,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"a3cb8069a5cc53b199fa668a642e62e3",

--- a/data/188/076/204/7/1880762047.geojson
+++ b/data/188/076/204/7/1880762047.geojson
@@ -168,7 +168,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"333d2c7353158ea65988f02c93be8d81",

--- a/data/188/076/205/1/1880762051.geojson
+++ b/data/188/076/205/1/1880762051.geojson
@@ -230,7 +230,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"3c140a0bf9190ebda4dd8399a994ef5b",

--- a/data/188/076/205/3/1880762053.geojson
+++ b/data/188/076/205/3/1880762053.geojson
@@ -239,7 +239,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"0c2c43726e07b4f527b0852e610b50b2",

--- a/data/188/076/205/5/1880762055.geojson
+++ b/data/188/076/205/5/1880762055.geojson
@@ -239,7 +239,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"6fbb179c816b23cbbf81cecccb269499",

--- a/data/188/076/205/7/1880762057.geojson
+++ b/data/188/076/205/7/1880762057.geojson
@@ -272,7 +272,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"f860fa811ab872ba5b20e9e974c9303e",

--- a/data/188/076/205/9/1880762059.geojson
+++ b/data/188/076/205/9/1880762059.geojson
@@ -212,7 +212,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"6b311a21ca493912d439101795097116",

--- a/data/188/076/206/1/1880762061.geojson
+++ b/data/188/076/206/1/1880762061.geojson
@@ -224,7 +224,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"208a195aa31f322f139e72d4880dca1c",

--- a/data/188/076/206/3/1880762063.geojson
+++ b/data/188/076/206/3/1880762063.geojson
@@ -56,7 +56,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"f775020105e5b47aa9fba04ebdc11ce6",

--- a/data/188/076/206/5/1880762065.geojson
+++ b/data/188/076/206/5/1880762065.geojson
@@ -227,7 +227,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"12e2f663abf4ce270a76a3792648d4d3",

--- a/data/188/076/206/9/1880762069.geojson
+++ b/data/188/076/206/9/1880762069.geojson
@@ -110,7 +110,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"ec857b6e7512e60bc2c4db3303417752",

--- a/data/188/076/207/1/1880762071.geojson
+++ b/data/188/076/207/1/1880762071.geojson
@@ -245,7 +245,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"e117384896d2366e2c099f50f4ec1bf5",

--- a/data/188/076/207/3/1880762073.geojson
+++ b/data/188/076/207/3/1880762073.geojson
@@ -227,7 +227,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"a9a9d267f84d03e03408c1d634979d18",

--- a/data/188/076/207/5/1880762075.geojson
+++ b/data/188/076/207/5/1880762075.geojson
@@ -209,7 +209,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"5f27c18a1eb566ee604efb3007865f53",

--- a/data/188/076/207/7/1880762077.geojson
+++ b/data/188/076/207/7/1880762077.geojson
@@ -236,7 +236,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"5bf99764f9ad51f793f374fe1846391f",

--- a/data/188/076/207/9/1880762079.geojson
+++ b/data/188/076/207/9/1880762079.geojson
@@ -245,7 +245,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"8a16ee3e9d961d5837c446f68a90cc84",

--- a/data/188/076/208/1/1880762081.geojson
+++ b/data/188/076/208/1/1880762081.geojson
@@ -158,7 +158,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"8d558a978212ae1c34a1ae9b81888dd9",

--- a/data/188/076/208/3/1880762083.geojson
+++ b/data/188/076/208/3/1880762083.geojson
@@ -155,7 +155,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"28782d4ad45a78a38bc8c69ddf41835f",

--- a/data/188/076/208/7/1880762087.geojson
+++ b/data/188/076/208/7/1880762087.geojson
@@ -110,7 +110,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"9e88ff929a2e7f98659224dc723bc7c4",

--- a/data/188/076/208/9/1880762089.geojson
+++ b/data/188/076/208/9/1880762089.geojson
@@ -44,7 +44,7 @@
     "wof:capital":[
         101750629
     ],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"d3a32b2f001b817384f90145b8bfac66",

--- a/data/188/076/209/1/1880762091.geojson
+++ b/data/188/076/209/1/1880762091.geojson
@@ -158,7 +158,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"3f9c951807bd3777c80fc679cba62fc7",

--- a/data/188/076/209/3/1880762093.geojson
+++ b/data/188/076/209/3/1880762093.geojson
@@ -41,7 +41,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"ff3e588ab60d647a26d92e4088eb5c38",

--- a/data/188/076/209/5/1880762095.geojson
+++ b/data/188/076/209/5/1880762095.geojson
@@ -41,7 +41,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"1916f4f65f3d507e977019c7f2d07316",

--- a/data/188/076/209/7/1880762097.geojson
+++ b/data/188/076/209/7/1880762097.geojson
@@ -68,7 +68,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"cfe5f99a010da0f1281c9f963a0f74f8",

--- a/data/188/076/209/9/1880762099.geojson
+++ b/data/188/076/209/9/1880762099.geojson
@@ -107,7 +107,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"27b3020528c3c605e0a750d24b728cd8",

--- a/data/188/076/210/1/1880762101.geojson
+++ b/data/188/076/210/1/1880762101.geojson
@@ -142,7 +142,7 @@
         404227471
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"1dc33772e45215325f0966c2b428855c",

--- a/data/188/076/210/5/1880762105.geojson
+++ b/data/188/076/210/5/1880762105.geojson
@@ -149,7 +149,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"e61d5283b0b5d68430c6c7e2377347d1",

--- a/data/188/076/210/7/1880762107.geojson
+++ b/data/188/076/210/7/1880762107.geojson
@@ -68,7 +68,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"e7bd82e11b39eef19eafa3db33fef95e",

--- a/data/188/076/210/9/1880762109.geojson
+++ b/data/188/076/210/9/1880762109.geojson
@@ -173,7 +173,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"12152581cd704862c85c166edccdac9c",

--- a/data/188/076/211/1/1880762111.geojson
+++ b/data/188/076/211/1/1880762111.geojson
@@ -83,7 +83,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"a1b87a8f59e87cbf9de8b26ee28f8d8d",

--- a/data/188/076/211/3/1880762113.geojson
+++ b/data/188/076/211/3/1880762113.geojson
@@ -86,7 +86,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"fb213671cd31fe4d5a0c6c4c93193abc",

--- a/data/188/076/211/5/1880762115.geojson
+++ b/data/188/076/211/5/1880762115.geojson
@@ -92,7 +92,7 @@
     "wof:capital":[
         101750397
     ],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"a5c5df500f89ee87883c17b524e65069",

--- a/data/188/076/211/7/1880762117.geojson
+++ b/data/188/076/211/7/1880762117.geojson
@@ -137,7 +137,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"859ed03b3499a4555f6be642ba4eb13f",

--- a/data/188/076/211/9/1880762119.geojson
+++ b/data/188/076/211/9/1880762119.geojson
@@ -323,7 +323,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"a378a426298789db1403b4c9e75150c8",

--- a/data/188/076/212/3/1880762123.geojson
+++ b/data/188/076/212/3/1880762123.geojson
@@ -158,7 +158,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"643d5146f5e949dc353019b574176808",

--- a/data/188/076/212/5/1880762125.geojson
+++ b/data/188/076/212/5/1880762125.geojson
@@ -170,7 +170,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"4b9847be8b0d451e30e75a7b7634f307",

--- a/data/188/076/212/7/1880762127.geojson
+++ b/data/188/076/212/7/1880762127.geojson
@@ -89,7 +89,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"0f869f4fd355b8ad42f381f625665737",

--- a/data/188/076/212/9/1880762129.geojson
+++ b/data/188/076/212/9/1880762129.geojson
@@ -50,7 +50,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"1bce554464597a5c9d6e826ad41a8e95",

--- a/data/188/076/213/1/1880762131.geojson
+++ b/data/188/076/213/1/1880762131.geojson
@@ -44,7 +44,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"e9cf3041fe4d2014766d9530af30a5b9",

--- a/data/188/076/213/3/1880762133.geojson
+++ b/data/188/076/213/3/1880762133.geojson
@@ -245,7 +245,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"1186f3544f2f6c1a5b33156fb70c053a",

--- a/data/188/076/213/5/1880762135.geojson
+++ b/data/188/076/213/5/1880762135.geojson
@@ -239,7 +239,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"281751b9b46a6246dcb67f6fbfb2e206",

--- a/data/188/076/213/7/1880762137.geojson
+++ b/data/188/076/213/7/1880762137.geojson
@@ -343,7 +343,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"5e3ba6a3774547e38498c073803ef8a0",

--- a/data/188/076/214/1/1880762141.geojson
+++ b/data/188/076/214/1/1880762141.geojson
@@ -248,7 +248,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"f9ece77724950e71f69a287257f8f836",

--- a/data/188/076/214/3/1880762143.geojson
+++ b/data/188/076/214/3/1880762143.geojson
@@ -230,7 +230,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"a1fc045191f6d9986cf91dbdf338ff93",

--- a/data/188/076/214/5/1880762145.geojson
+++ b/data/188/076/214/5/1880762145.geojson
@@ -227,7 +227,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"cf38fb329e404b3689e61cb439b546fc",

--- a/data/188/076/214/7/1880762147.geojson
+++ b/data/188/076/214/7/1880762147.geojson
@@ -182,7 +182,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"add7d99f1a1eacecb6b03b697a70370d",

--- a/data/188/076/214/9/1880762149.geojson
+++ b/data/188/076/214/9/1880762149.geojson
@@ -278,7 +278,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"975910b1fc172fe5702eed4d0aca75a3",

--- a/data/188/076/215/1/1880762151.geojson
+++ b/data/188/076/215/1/1880762151.geojson
@@ -248,7 +248,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"d997554fab9c0c2bd289dcae3b4963b9",

--- a/data/188/076/215/3/1880762153.geojson
+++ b/data/188/076/215/3/1880762153.geojson
@@ -242,7 +242,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"b47574e8dd80ec27a5d39321d2521647",

--- a/data/188/076/215/5/1880762155.geojson
+++ b/data/188/076/215/5/1880762155.geojson
@@ -257,7 +257,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"df800955950d77d8617da7baebdaa661",

--- a/data/188/076/215/9/1880762159.geojson
+++ b/data/188/076/215/9/1880762159.geojson
@@ -260,7 +260,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"6b3585db9e922b727c01d2ec17a4bd89",

--- a/data/188/076/216/1/1880762161.geojson
+++ b/data/188/076/216/1/1880762161.geojson
@@ -239,7 +239,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"33c0f15093f40af010e52c68dcc1846e",

--- a/data/188/076/216/3/1880762163.geojson
+++ b/data/188/076/216/3/1880762163.geojson
@@ -245,7 +245,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"7979ac004641cdc22ac9abb5eb062263",

--- a/data/188/076/216/5/1880762165.geojson
+++ b/data/188/076/216/5/1880762165.geojson
@@ -254,7 +254,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"a2cb6f210704530a0a8b44c208028dbe",

--- a/data/188/076/216/7/1880762167.geojson
+++ b/data/188/076/216/7/1880762167.geojson
@@ -242,7 +242,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"cafd3c6d7cdc60d6984688624e5eb6d9",

--- a/data/188/076/216/9/1880762169.geojson
+++ b/data/188/076/216/9/1880762169.geojson
@@ -74,7 +74,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"a34b570c99e41ac3f75f61d8dfdd57ce",

--- a/data/188/076/217/1/1880762171.geojson
+++ b/data/188/076/217/1/1880762171.geojson
@@ -41,7 +41,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"f6e84d2690d7a9d0e283b5e3a631b1a0",

--- a/data/188/076/217/3/1880762173.geojson
+++ b/data/188/076/217/3/1880762173.geojson
@@ -47,7 +47,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"419b0ca45b337333c77096adfe483346",

--- a/data/188/076/217/7/1880762177.geojson
+++ b/data/188/076/217/7/1880762177.geojson
@@ -41,7 +41,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"86d49866585debd11805b1121f86aa5c",

--- a/data/188/076/217/9/1880762179.geojson
+++ b/data/188/076/217/9/1880762179.geojson
@@ -263,7 +263,7 @@
     "wof:capital":[
         101750367
     ],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"9c664db27ccb9bf8b51a9500dd241983",

--- a/data/188/076/218/1/1880762181.geojson
+++ b/data/188/076/218/1/1880762181.geojson
@@ -89,7 +89,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"610ea06148d375f86a96faabf73858f5",

--- a/data/188/076/218/3/1880762183.geojson
+++ b/data/188/076/218/3/1880762183.geojson
@@ -92,7 +92,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"85504b016fb4c39ee2d93ce845588148",

--- a/data/188/076/218/5/1880762185.geojson
+++ b/data/188/076/218/5/1880762185.geojson
@@ -80,7 +80,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"df6814056632916e3cd431914c154f8d",

--- a/data/188/076/218/7/1880762187.geojson
+++ b/data/188/076/218/7/1880762187.geojson
@@ -158,7 +158,7 @@
         136253055
     ],
     "wof:breaches":[],
-    "wof:concordances":[],
+    "wof:concordances":{},
     "wof:coterminous":[],
     "wof:country":"GB",
     "wof:geomhash":"2be591fcff72f19e92f05c9846ca7b7e",


### PR DESCRIPTION
Following the standard, the field `wof:concordances` must be an object and not an array, even when it is empty.

This is a specific issue for the GB repository, under `data/188/076`.