### PR TITLE
Fix hierarchy for Kinlochleven

### DIFF
--- a/data/112/603/365/3/1126033653.geojson
+++ b/data/112/603/365/3/1126033653.geojson
@@ -113,12 +113,14 @@
     "wof:geomhash":"53e46ea69b6b8239082f4a4bff0d04f8",
     "wof:hierarchy":[
         {
-            "continent_id":-1,
-            "country_id":-1,
+            "continent_id":102191581,
+            "country_id":85633159,
             "county_id":1360699045,
+            "empire_id":136253055,
             "locality_id":1126033653,
             "macrocounty_id":1880762005,
-            "region_id":-1
+            "macroregion_id":404227471,
+            "region_id":1880773131
         }
     ],
     "wof:id":1126033653,


### PR DESCRIPTION
Title says it all. User of one of our APIs backed by WOF pointed out this inconsistency. I backfilled the missing props from the parent (https://spelunker.whosonfirst.org/id/1360699045).